### PR TITLE
Update safe-coloured-text to use -terminfo split package

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -21,10 +21,11 @@ extra-deps:
   commit: 9059edbd30c7d3b07cd97306158c4f2f33bb7a44
   subdirs:
     - yamlparse-applicative
-- github: NorfairKing/safe-coloured-text
-  commit: 9db3defadd2d2f05b2db02b551c6458fc4d7c10b
+- github: notquiteamonad/safe-coloured-text
+  commit: 43232c2c1b3038fbb1d3d384709756223da2f709
   subdirs:
     - safe-coloured-text
+    - safe-coloured-text-terminfo
 
 ghc-options:
   "$locals": -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Widentities -Wredundant-constraints -Wcpp-undef

--- a/sydtest/output-test/Spec.hs
+++ b/sydtest/output-test/Spec.hs
@@ -18,6 +18,7 @@ import Test.QuickCheck
 import Test.Syd
 import Test.Syd.OptParse
 import Text.Colour
+import Text.Colour.Capabilities.FromEnv
 
 data DangerousRecord = Cons1 {field :: String} | Cons2
 

--- a/sydtest/package.yaml
+++ b/sydtest/package.yaml
@@ -35,6 +35,7 @@ library:
     - random-shuffle
     - safe
     - safe-coloured-text
+    - safe-coloured-text-terminfo
     - split
     - text
     - yaml
@@ -71,5 +72,6 @@ tests:
     - path
     - path-io
     - safe-coloured-text
+    - safe-coloured-text-terminfo
     - sydtest
     - text

--- a/sydtest/src/Test/Syd/Runner.hs
+++ b/sydtest/src/Test/Syd/Runner.hs
@@ -26,6 +26,7 @@ import Test.Syd.Runner.Asynchronous
 import Test.Syd.Runner.Synchronous
 import Test.Syd.SpecDef
 import Text.Colour
+import Text.Colour.Capabilities.FromEnv
 import Text.Printf
 
 sydTestResult :: Settings -> TestDefM '[] () r -> IO (Timed ResultForest)

--- a/sydtest/sydtest.cabal
+++ b/sydtest/sydtest.cabal
@@ -71,6 +71,7 @@ library
     , random-shuffle
     , safe
     , safe-coloured-text
+    , safe-coloured-text-terminfo
     , split
     , text
     , yaml
@@ -92,6 +93,7 @@ test-suite sydtest-output-test
     , path
     , path-io
     , safe-coloured-text
+    , safe-coloured-text-terminfo
     , sydtest
     , text
   default-language: Haskell2010


### PR DESCRIPTION
Updates the `safe-coloured-text` dependency to use the split-out `-terminfo` package.