### PR TITLE
Add golden tests for Data.Aeson

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -16,6 +16,7 @@ packages:
 - sydtest-typed-process
 - sydtest-wai
 - sydtest-yesod
+- sydtest-aeson
 extra-deps:
 - envparse-0.4.1@sha256:989902e6368532548f61de1fa245ad2b39176cddd8743b20071af519a709ce30,2842
 - github: NorfairKing/yamlparse-applicative

--- a/sydtest-aeson/.gitignore
+++ b/sydtest-aeson/.gitignore
@@ -1,0 +1,2 @@
+.stack-work/
+*~

--- a/sydtest-aeson/LICENSE.md
+++ b/sydtest-aeson/LICENSE.md
@@ -1,0 +1,5 @@
+# Sydtest License
+
+Copyright (c) 2021 Tom Sydney Kerckhove
+
+See the Sydtest License at https://github.com/NorfairKing/sydtest/blob/master/sydtest/LICENSE.md for the full license text.

--- a/sydtest-aeson/package.yaml
+++ b/sydtest-aeson/package.yaml
@@ -1,0 +1,51 @@
+name: sydtest-aeson
+version: 0.0.0.0
+github: "NorfairKing/sydtest"
+license: OtherLicense
+license-file: LICENSE.md
+author: "Tom Sydney Kerckhove"
+maintainer: "syd@cs-syd.eu"
+copyright: "Copyright (c) 2021 Tom Sydney Kerckhove"
+category: Testing
+synopsis: An aeson companion library for sydtest
+
+
+dependencies:
+- base >= 4.7 && < 5
+
+library:
+  source-dirs: src
+  dependencies:
+  - aeson
+  - bytestring
+  - path
+  - path-io
+  - sydtest
+
+tests:
+  sydtest-aeson-test:
+    main: Spec.hs
+    source-dirs: test
+    build-tools: sydtest-discover
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    - -Wall
+    dependencies:
+    - aeson
+    - sydtest
+    - sydtest-aeson
+    - text
+    when:
+      - condition: flag(sydtest_integration_tests)
+        then:
+          buildable: True
+        else:
+          buildable: False
+
+flags:
+  sydtest_integration_tests:
+    description: Whether to allow building integration tests
+    manual: false
+    default: true

--- a/sydtest-aeson/src/Test/Syd/Aeson.hs
+++ b/sydtest-aeson/src/Test/Syd/Aeson.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Syd.Aeson
+  ( -- * Golden tests
+    goldenAesonDocumentFile,
+    pureGoldenAesonDocumentFile,
+  )
+where
+
+import Data.Aeson as Aeson
+import qualified Data.ByteString as SB
+import qualified Data.ByteString.Lazy as LB
+import Path
+import Path.IO
+import Test.Syd
+
+-- | Test that the produced 'Aeson.Value' is the same as what we find in the given golden file.
+goldenAesonDocumentFile :: FilePath -> IO Aeson.Value -> GoldenTest Aeson.Value
+goldenAesonDocumentFile fp produceActualDocument =
+  GoldenTest
+    { goldenTestRead = do
+        ap <- resolveFile' fp
+        exists <- doesFileExist ap
+        if exists
+          then decodeFileStrict' fp
+          else pure Nothing,
+      goldenTestProduce = produceActualDocument,
+      goldenTestWrite = \d -> do
+        ap <- resolveFile' fp
+        ensureDir (parent ap)
+        SB.writeFile (fromAbsFile ap) $ LB.toStrict $ Aeson.encode d,
+      goldenTestCompare = \actual expected ->
+        if actual == expected
+          then Nothing
+          else Just (Context (stringsNotEqualButShouldHaveBeenEqual (ppShow actual) (ppShow expected)) (goldenContext fp))
+    }
+
+-- | Test that the given 'Aeson.Value' is the same as what we find in the given golden file.
+pureGoldenAesonDocumentFile :: FilePath -> Aeson.Value -> GoldenTest Aeson.Value
+pureGoldenAesonDocumentFile fp actualDocument = goldenAesonDocumentFile fp $ pure actualDocument

--- a/sydtest-aeson/sydtest-aeson.cabal
+++ b/sydtest-aeson/sydtest-aeson.cabal
@@ -1,0 +1,68 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 3effb7154c7fdbcd6eb587c29f54a450305cf561bc7ffae845e216bc4bee6f6a
+
+name:           sydtest-aeson
+version:        0.0.0.0
+synopsis:       An aeson companion library for sydtest
+category:       Testing
+homepage:       https://github.com/NorfairKing/sydtest#readme
+bug-reports:    https://github.com/NorfairKing/sydtest/issues
+author:         Tom Sydney Kerckhove
+maintainer:     syd@cs-syd.eu
+copyright:      Copyright (c) 2021 Tom Sydney Kerckhove
+license:        OtherLicense
+license-file:   LICENSE.md
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/NorfairKing/sydtest
+
+flag sydtest_integration_tests
+  description: Whether to allow building integration tests
+  manual: False
+  default: True
+
+library
+  exposed-modules:
+      Test.Syd.Aeson
+  other-modules:
+      Paths_sydtest_aeson
+  hs-source-dirs:
+      src
+  build-depends:
+      aeson
+    , base >=4.7 && <5
+    , bytestring
+    , path
+    , path-io
+    , sydtest
+  default-language: Haskell2010
+
+test-suite sydtest-aeson-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Test.Syd.AesonSpec
+      Paths_sydtest_aeson
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
+  build-tool-depends:
+      sydtest-discover:sydtest-discover
+  build-depends:
+      aeson
+    , base >=4.7 && <5
+    , sydtest
+    , sydtest-aeson
+    , text
+  if flag(sydtest_integration_tests)
+    buildable: True
+  else
+    buildable: False
+  default-language: Haskell2010

--- a/sydtest-aeson/test/Spec.hs
+++ b/sydtest-aeson/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF sydtest-discover #-}

--- a/sydtest-aeson/test/Test/Syd/AesonSpec.hs
+++ b/sydtest-aeson/test/Test/Syd/AesonSpec.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Syd.AesonSpec (spec) where
+
+import Data.Text (Text)
+import Data.Aeson as Aeson
+import Test.Syd
+import Test.Syd.Aeson
+
+spec :: Spec
+spec = do
+  describe "pureGoldenAesonDocumentFile" $
+    it "outputs this example the same as before" $
+      pureGoldenAesonDocumentFile
+        "test_resources/pure-example.json"
+        $ Aeson.object 
+            [ "hello" .= ( "world" :: Text ), "a" .= ( 1 :: Int ), "b" .= True ]
+  describe "goldenAesonDocumentFile" $
+    it "outputs this example the same as before" $
+      goldenAesonDocumentFile
+        "test_resources/example.json"
+        $ pure $ Aeson.object [ "hello" .= ( "world" :: Text ), "a" .= ( 1 :: Int ), "b" .= True ]

--- a/sydtest-aeson/test_resources/example.json
+++ b/sydtest-aeson/test_resources/example.json
@@ -1,0 +1,5 @@
+{
+  "hello" : "world",
+  "a" : 1,
+  "b" : true
+}

--- a/sydtest-aeson/test_resources/pure-example.json
+++ b/sydtest-aeson/test_resources/pure-example.json
@@ -1,0 +1,5 @@
+{
+  "hello" : "world",
+  "a" : 1,
+  "b" : true
+}


### PR DESCRIPTION
### SUMMARY

Brings a new module `Test.Syd.Aeson` which exposes two new functions for executing golden tests on instances of `ToJSON` and `FromJSON` (exposed by the `Data.Aeson` package).
