### PR TITLE
use isPrefixOf instead of isInfixOf for shouldStartWith

### DIFF
--- a/sydtest/CHANGELOG.md
+++ b/sydtest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.0.1] - 2021-12-23
+
+### Changed
+
+* Fixed `shouldStartWith` to test on the prefix rather then infix
+
 ## [0.7.0.0] - 2021-12-15
 
 ### Added

--- a/sydtest/package.yaml
+++ b/sydtest/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest
-version: 0.7.0.0
+version: 0.7.0.1
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest/src/Test/Syd/Expectation.hs
+++ b/sydtest/src/Test/Syd/Expectation.hs
@@ -67,7 +67,7 @@ infix 1 `shouldNotReturn`
 
 -- | Assert that the given list has the given prefix
 shouldStartWith :: (HasCallStack, Show a, Eq a) => [a] -> [a] -> Expectation
-shouldStartWith a i = shouldSatisfyNamed a ("has infix\n" <> ppShow i) (isInfixOf i)
+shouldStartWith a i = shouldSatisfyNamed a ("has prefix\n" <> ppShow i) (isPrefixOf i)
 
 infix 1 `shouldStartWith`
 

--- a/sydtest/sydtest.cabal
+++ b/sydtest/sydtest.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest
-version:        0.7.0.0
+version:        0.7.0.1
 synopsis:       A modern testing framework for Haskell with good defaults and advanced testing features.
 description:    A modern testing framework for Haskell with good defaults and advanced testing features. Sydtest aims to make the common easy and the hard possible. See https://github.com/NorfairKing/sydtest#readme for more information.
 category:       Testing


### PR DESCRIPTION
This fixes https://github.com/NorfairKing/sydtest/issues/31.

I was not able to run the tests as to https://github.com/NorfairKing/sydtest/blob/373a72f6763e2ebf90e6a9de137349e1568540a8/CONTRIBUTING.md because the compilation of `safe-coloured-text-terminfo` fails with (and I am unsure how to fix it):

```
safe-coloured-text-terminfo> /usr/bin/ld.gold: error: cannot find -ltinfo
safe-coloured-text-terminfo> collect2: error: ld returned 1 exit status
safe-coloured-text-terminfo> `gcc' failed in phase `Linker'. (Exit code: 1)
```

`nix-build ci.nix` works. Could you check if the tests are succeeding on your end or do you have a hint on how to fix this error?

Stack version: Version 2.7.3, Git revision 7927a3aec32e2b2e5e4fb5be76d0d50eddcc197f x86_64 hpack-0.34.4