### PR TITLE
Add servantSpec functions that allow passing a context

### DIFF
--- a/sydtest-servant/package.yaml
+++ b/sydtest-servant/package.yaml
@@ -42,3 +42,4 @@ tests:
     - stm
     - sydtest
     - sydtest-servant
+    - sydtest-wai

--- a/sydtest-servant/sydtest-servant.cabal
+++ b/sydtest-servant/sydtest-servant.cabal
@@ -46,7 +46,9 @@ test-suite sydtest-servant-test
   main-is: Spec.hs
   other-modules:
       Test.Syd.Servant.Example
+      Test.Syd.Servant.ExampleWithContext
       Test.Syd.ServantSpec
+      Test.Syd.ServantWithContextSpec
       Paths_sydtest_servant
   hs-source-dirs:
       test

--- a/sydtest-servant/sydtest-servant.cabal
+++ b/sydtest-servant/sydtest-servant.cabal
@@ -63,4 +63,5 @@ test-suite sydtest-servant-test
     , stm
     , sydtest
     , sydtest-servant
+    , sydtest-wai
   default-language: Haskell2010

--- a/sydtest-servant/test/Test/Syd/Servant/ExampleWithContext.hs
+++ b/sydtest-servant/test/Test/Syd/Servant/ExampleWithContext.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Syd.Servant.ExampleWithContext where
+
+import Control.Concurrent.STM
+import Control.Monad.IO.Class
+import Servant
+import Servant.Client
+
+exampleAPI :: Proxy ExampleAPI
+exampleAPI = Proxy
+
+newtype User = User String
+
+type ExampleAPI =
+  BasicAuth "test" User
+    :> ( "get" :> Get '[JSON] Int
+           :<|> "add" :> ReqBody '[JSON] Int :> Post '[JSON] NoContent
+       )
+
+exampleServer :: TVar Int -> Server ExampleAPI
+exampleServer var = const $ serveGet :<|> serveAdd
+  where
+    serveGet :: Handler Int
+    serveGet = liftIO $ readTVarIO var
+    serveAdd :: Int -> Handler NoContent
+    serveAdd i = do
+      liftIO $ atomically $ modifyTVar var (+ i)
+      pure NoContent
+
+exampleApplication :: TVar Int -> Application
+exampleApplication var = serveWithContext exampleAPI exampleContext (exampleServer var)
+
+exampleContext :: Context '[BasicAuthCheck User]
+exampleContext = checkBasicAuth :. EmptyContext
+
+checkBasicAuth :: BasicAuthCheck User
+checkBasicAuth = BasicAuthCheck $ \basicAuthData ->
+  let username = basicAuthUsername basicAuthData
+      password = basicAuthPassword basicAuthData
+   in pure $ if username == "foo" && password == "bar" then Authorized (User "foo") else Unauthorized
+
+clientGetCorrectCredentials :: ClientM Int
+clientAddCorrectCredentials :: Int -> ClientM NoContent
+(clientGetCorrectCredentials :<|> clientAddCorrectCredentials) = client exampleAPI BasicAuthData {basicAuthUsername = "foo", basicAuthPassword = "bar"}
+
+clientGetWrongCredentials :: ClientM Int
+clientAddWrongCredentials :: Int -> ClientM NoContent
+(clientGetWrongCredentials :<|> clientAddWrongCredentials) = client exampleAPI BasicAuthData {basicAuthUsername = "wrong", basicAuthPassword = "wrong"}

--- a/sydtest-servant/test/Test/Syd/ServantWithContextSpec.hs
+++ b/sydtest-servant/test/Test/Syd/ServantWithContextSpec.hs
@@ -1,0 +1,22 @@
+module Test.Syd.ServantWithContextSpec (spec) where
+
+import Control.Concurrent.STM
+import Servant
+import Test.Syd
+import Test.Syd.Servant
+import Test.Syd.Servant.ExampleWithContext
+
+exampleSetupFunc :: SetupFunc (Server ExampleAPI)
+exampleSetupFunc = SetupFunc $ \func -> do
+  var <- newTVarIO 0
+  func $ exampleServer var
+
+spec :: Spec
+spec = servantSpecWithSetupFuncWithContext exampleAPI exampleContext exampleSetupFunc $ do
+  it "gets zero at the start" $ do
+    r <- clientGetCorrectCredentials
+    liftIO $ r `shouldBe` 0
+  it "can add 1 to get 1" $ do
+    NoContent <- clientAddCorrectCredentials 1
+    r <- clientGetCorrectCredentials
+    liftIO $ r `shouldBe` 1

--- a/sydtest-servant/test/Test/Syd/ServantWithContextSpec.hs
+++ b/sydtest-servant/test/Test/Syd/ServantWithContextSpec.hs
@@ -2,9 +2,11 @@ module Test.Syd.ServantWithContextSpec (spec) where
 
 import Control.Concurrent.STM
 import Servant
+import Servant.Client
 import Test.Syd
 import Test.Syd.Servant
 import Test.Syd.Servant.ExampleWithContext
+import Test.Syd.Wai
 
 exampleSetupFunc :: SetupFunc (Server ExampleAPI)
 exampleSetupFunc = SetupFunc $ \func -> do
@@ -13,10 +15,22 @@ exampleSetupFunc = SetupFunc $ \func -> do
 
 spec :: Spec
 spec = servantSpecWithSetupFuncWithContext exampleAPI exampleContext exampleSetupFunc $ do
-  it "gets zero at the start" $ do
-    r <- clientGetCorrectCredentials
-    liftIO $ r `shouldBe` 0
-  it "can add 1 to get 1" $ do
-    NoContent <- clientAddCorrectCredentials 1
-    r <- clientGetCorrectCredentials
-    liftIO $ r `shouldBe` 1
+  describe "requests with correct credentials" $ do
+    it "gets zero at the start" $ do
+      r <- clientGetCorrectCredentials
+      liftIO $ r `shouldBe` 0
+    it "can add 1 to get 1" $ do
+      NoContent <- clientAddCorrectCredentials 1
+      r <- clientGetCorrectCredentials
+      liftIO $ r `shouldBe` 1
+  describe "requests with incorrect credentials" $ do
+    it "doesn't allow GET requests without correct credentials" $ \clientEnv -> do
+      errOrResult <- testClientOrError clientEnv clientGetWrongCredentials
+      case errOrResult of
+        Left (FailureResponse _ res) -> responseStatusCode res `shouldBe` forbidden403
+        res -> expectationFailure $ "Expected a failed request with status 403, but got " <> show res
+    it "doesn't allow POST requests without correct credentials" $ \clientEnv -> do
+      errOrResult <- testClientOrError clientEnv $ clientAddWrongCredentials 1
+      case errOrResult of
+        Left (FailureResponse _ res) -> responseStatusCode res `shouldBe` forbidden403
+        res -> expectationFailure $ "Expected a failed request with status 403, but got " <> show res


### PR DESCRIPTION
This addresses #42. I tried to be as minimal as possible in the test (maybe it's even a bit too simplistic, but it's enough to show that it works) 

Closes #42 