### PR TITLE
Add missing IsTest instances so that Hedgehog properties can be run with resources

### DIFF
--- a/sydtest-hedgehog/CHANGELOG.md
+++ b/sydtest-hedgehog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.0.0] - 2022-05-10
+
+### Added
+
+* `IsTest` instances for properties with args
+
 ## [0.2.0.0] - 2022-04-28
 
 ### Added

--- a/sydtest-hedgehog/package.yaml
+++ b/sydtest-hedgehog/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest-hedgehog
-version: 0.2.0.0
+version: 0.3.0.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest-hedgehog/sydtest-hedgehog.cabal
+++ b/sydtest-hedgehog/sydtest-hedgehog.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest-hedgehog
-version:        0.2.0.0
+version:        0.3.0.0
 synopsis:       A Hedgehog companion library for sydtest
 category:       Testing
 homepage:       https://github.com/NorfairKing/sydtest#readme

--- a/sydtest-hedgehog/test/Test/Syd/HedgehogSpec.hs
+++ b/sydtest-hedgehog/test/Test/Syd/HedgehogSpec.hs
@@ -16,6 +16,18 @@ spec = do
       property $ do
         xs <- forAll $ Gen.list (Range.linear 0 100) Gen.alpha
         reverse (reverse xs) === xs
+  setupAroundWith (const (pure 0)) $
+    describe "reverse with setup" $ do
+      specify "reversing twice is the same as not reversing" $ \i ->
+        property $ do
+          xs <- forAll $ Gen.list (Range.linear i 100) Gen.alpha
+          reverse (reverse xs) === xs
+  beforeAll (pure (1 :: Int)) $ do
+    describe "reverse with beforeAll" $ do
+      specifyWithBoth "reversing twice is the same as not reversing" $ \i () ->
+        property $ do
+          xs <- forAll $ Gen.list (Range.linear i 100) Gen.alpha
+          reverse (reverse xs) === xs
 
 exampleHedgehogGroup :: Hedgehog.Group
 exampleHedgehogGroup =


### PR DESCRIPTION
See #49.

I renamed `runHedgehogProperty` to `runHedgehogPropertyWithArg` (similar to `runPropertyTestWithArg`).
I also moved the creation of `config` into the function that applies the wrapper as I need access to the args.

Let me know what you think!