### PR TITLE
add a `shouldMatchList` combinator

### DIFF
--- a/sydtest/CHANGELOG.md
+++ b/sydtest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.11.0.2] - 2022-09-7
+
+### Changed
+
+* Added the `shouldMatchList` expectation, corresponding the one from
+  `hspec-expectations`.
+
 ## [0.11.0.1] - 2022-06-28
 
 ### Changed

--- a/sydtest/package.yaml
+++ b/sydtest/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest
-version: 0.11.0.1
+version: 0.11.0.2
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest/src/Test/Syd.hs
+++ b/sydtest/src/Test/Syd.hs
@@ -99,6 +99,7 @@ module Test.Syd
     shouldStartWith,
     shouldEndWith,
     shouldContain,
+    shouldMatchList,
     expectationFailure,
     context,
     Expectation,

--- a/sydtest/src/Test/Syd/Expectation.hs
+++ b/sydtest/src/Test/Syd/Expectation.hs
@@ -83,6 +83,13 @@ shouldContain a i = shouldSatisfyNamed a ("has infix\n" <> ppShow i) (isInfixOf 
 
 infix 1 `shouldContain`
 
+-- | Assert that the given list contains all elements from the other
+-- given list and only them, perhaps in a different order.
+shouldMatchList :: (HasCallStack, Show a, Eq a) => [a] -> [a] -> Expectation
+shouldMatchList a b = shouldSatisfyNamed a ("matches list\n" <> ppShow b) (matches b)
+  where
+    matches x y = null (x \\ y) && null (y \\ x)
+
 -- | Assert that two 'String's are equal according to `==`.
 --
 -- Note that using function could mess up the colours in your terminal if the Texts contain ANSI codes.

--- a/sydtest/sydtest.cabal
+++ b/sydtest/sydtest.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           sydtest
-version:        0.11.0.1
+version:        0.11.0.2
 synopsis:       A modern testing framework for Haskell with good defaults and advanced testing features.
 description:    A modern testing framework for Haskell with good defaults and advanced testing features. Sydtest aims to make the common easy and the hard possible. See https://github.com/NorfairKing/sydtest#readme for more information.
 category:       Testing
@@ -86,13 +86,13 @@ library
     , split
     , stm
     , text
+  default-language: Haskell2010
   if os(windows)
     build-depends:
         ansi-terminal
   else
     build-depends:
         safe-coloured-text-terminfo
-  default-language: Haskell2010
 
 test-suite sydtest-output-test
   type: exitcode-stdio-1.0
@@ -112,10 +112,10 @@ test-suite sydtest-output-test
     , safe-coloured-text
     , sydtest
     , text
+  default-language: Haskell2010
   if !os(windows)
     build-depends:
         safe-coloured-text-terminfo
-  default-language: Haskell2010
 
 test-suite sydtest-test
   type: exitcode-stdio-1.0


### PR DESCRIPTION
The motivation for adding it is that it's present in the
     hspec-expectations library and is occasionaly useful