### PR TITLE
Fix missing build tool for multi-discover-test

### DIFF
--- a/sydtest/package.yaml
+++ b/sydtest/package.yaml
@@ -95,6 +95,7 @@ tests:
   sydtest-multi-discover-test:
     main: Main.hs
     source-dirs: multi-discover-test
+    build-tools: sydtest-discover
     ghc-options:
     - -threaded
     - -rtsopts

--- a/sydtest/sydtest.cabal
+++ b/sydtest/sydtest.cabal
@@ -116,6 +116,8 @@ test-suite sydtest-multi-discover-test
   hs-source-dirs:
       multi-discover-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-tool-depends:
+      sydtest-discover:sydtest-discover
   build-depends:
       base >=4.7 && <5
     , sydtest


### PR DESCRIPTION
This PR fixes executing `cabal test` which currently fails because its missing the required build tool. In the Nix build this was not discovered because the build tool was added by other test suites.