### PR TITLE
fix filter flag parsing

### DIFF
--- a/sydtest-test/package.yaml
+++ b/sydtest-test/package.yaml
@@ -28,6 +28,7 @@ tests:
     - QuickCheck
     - bytestring
     - fast-myers-diff
+    - optparse-applicative
     - path
     - path-io
     - safe-coloured-text

--- a/sydtest-test/sydtest-test.cabal
+++ b/sydtest-test/sydtest-test.cabal
@@ -90,6 +90,7 @@ test-suite sydtest-test
       Test.Syd.ExpectationSpec
       Test.Syd.FootgunSpec
       Test.Syd.GoldenSpec
+      Test.Syd.OptParseSpec
       Test.Syd.PathSpec
       Test.Syd.ScenarioSpec
       Test.Syd.SequentialSpec
@@ -107,6 +108,7 @@ test-suite sydtest-test
     , base >=4.7 && <5
     , bytestring
     , fast-myers-diff
+    , optparse-applicative
     , path
     , path-io
     , safe-coloured-text

--- a/sydtest-test/test/Test/Syd/OptParseSpec.hs
+++ b/sydtest-test/test/Test/Syd/OptParseSpec.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Syd.OptParseSpec (spec) where
+
+import Test.Syd
+import Test.Syd.OptParse (flagsParser, Flags(..), prefs_)
+import Options.Applicative (execParserPure, getParseResult)
+import Data.Text (Text)
+
+spec :: Spec
+spec = do
+  describe "filter flags" $ do
+    it "single flag" $
+      parse_filter_flags ["--filter", "foo"] `shouldBe` Just ["foo"]
+    it "two flags" $
+      parse_filter_flags ["--filter", "foo", "--filter", "bar"] `shouldBe` Just ["foo", "bar"]
+    it "single flag with spaces" $
+      parse_filter_flags ["--filter", "foo bar"] `shouldBe` Just ["foo bar"]
+    it "two flags, one with spaces" $
+      parse_filter_flags ["--filter", "foo", "--filter", "bar biz"] `shouldBe` Just ["foo", "bar biz"]
+  where 
+    parse_filter_flags :: [String] -> Maybe [Text]
+    parse_filter_flags cli_args = 
+      let 
+        parser_result = execParserPure prefs_ flagsParser cli_args
+        mb_flags      = getParseResult parser_result :: Maybe Flags
+      in flagFilters <$> mb_flags

--- a/sydtest/CONTRIBUTORS
+++ b/sydtest/CONTRIBUTORS
@@ -3,3 +3,4 @@ igrep
 mrcjkb
 L7R7
 TheOddler
+Nova In Silico

--- a/sydtest/src/Test/Syd/OptParse.hs
+++ b/sydtest/src/Test/Syd/OptParse.hs
@@ -667,7 +667,7 @@ parseFlags =
     <*> doubleSwitch ["profile"] (help "Turn on profiling mode.")
 
 manyOptional :: OptParse.Mod OptionFields [Text] -> OptParse.Parser [Text]
-manyOptional modifier = mconcat <$> many (option (str <&> T.words) modifier)
+manyOptional modifier = mconcat <$> many (option (str <&> (: [])) modifier)
 
 seedSettingFlags :: OptParse.Parser (Maybe SeedSetting)
 seedSettingFlags =


### PR DESCRIPTION
This PR addresses https://github.com/NorfairKing/sydtest/issues/81

It modifies `Test.Syd.OptParse.manyOptional` such that it no longer splits texts on spaces. 
The PR also adds some unit tests for the parsing of filter flags.