### PR TITLE
Timeout of diff algrorithm

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "fast-myers-diff": {
       "flake": false,
       "locked": {
-        "lastModified": 1717390032,
-        "narHash": "sha256-7O9MA3G8CQtiAQaTsj5WskieLR0BhjfFAQsq7CWJFnQ=",
+        "lastModified": 1725809875,
+        "narHash": "sha256-csh7DuQAtoIWgEKEGj+GcRrmO9Ue6a7QyNAtY3yNsLc=",
         "owner": "NorfairKing",
         "repo": "fast-myers-diff",
-        "rev": "ac52f5779739c46aa1c014108bbbd1e7464cdf75",
+        "rev": "d7c1a675af3889698b987485a630f96a993226fa",
         "type": "github"
       },
       "original": {

--- a/sydtest-mongo/src/Test/Syd/MongoDB.hs
+++ b/sydtest-mongo/src/Test/Syd/MongoDB.hs
@@ -59,10 +59,11 @@ goldenBSONDocumentFile fp produceActualDocument =
         ensureDir (parent ap)
         SB.writeFile (fromAbsFile ap) $ LB.toStrict $ runPut $ putDocument d,
       goldenTestCompare = \actual expected ->
-        pure $
-          if actual == expected
-            then Nothing
-            else Just (Context (stringsNotEqualButShouldHaveBeenEqual (ppShow actual) (ppShow expected)) (goldenContext fp))
+        if actual == expected
+          then pure Nothing
+          else do
+            assertion <- stringsNotEqualButShouldHaveBeenEqual (ppShow actual) (ppShow expected)
+            pure $ Just (Context assertion (goldenContext fp))
     }
 
 -- | Test that the given 'Bson.Document' is the same as what we find in the given golden file.

--- a/sydtest-test/output-test/Spec.hs
+++ b/sydtest-test/output-test/Spec.hs
@@ -128,12 +128,12 @@ spec = do
         { goldenTestRead = pure (Just ()),
           goldenTestProduce = pure (),
           goldenTestWrite = \() -> pure (),
-          goldenTestCompare = \actual expected -> pure $ case 1 `div` (0 :: Int) of
-            1 -> Nothing
+          goldenTestCompare = \actual expected -> case 1 `div` (0 :: Int) of
+            1 -> pure Nothing
             _ ->
               if actual == expected
-                then Nothing
-                else Just $ NotEqualButShouldHaveBeenEqual (show actual) (show expected)
+                then pure Nothing
+                else Just <$> mkNotEqualButShouldHaveBeenEqual (show actual) (show expected)
         }
 
     describe "outputResultForest" $ do

--- a/sydtest-test/test/Test/Syd/DiffSpec.hs
+++ b/sydtest-test/test/Test/Syd/DiffSpec.hs
@@ -287,4 +287,6 @@ spec = do
 
   describe "outputEqualityAssertionFailed" $ do
     it "can output a large diff quickly enough" $
-      length (outputEqualityAssertionFailed (replicate 10000 'a') "b") `shouldBe` 3
+      let a = replicate 10000 'a'
+          b = "b"
+       in length (outputEqualityAssertionFailed a b (Just $ computeDiff a b)) `shouldBe` 3

--- a/sydtest-test/test/Test/Syd/TimingSpec.hs
+++ b/sydtest-test/test/Test/Syd/TimingSpec.hs
@@ -6,7 +6,10 @@
 module Test.Syd.TimingSpec (spec) where
 
 import Control.Concurrent
+import Control.Exception (try)
+import GHC.IO.Exception (ExitCode)
 import System.IO.Unsafe
+import System.Timeout (timeout)
 import Test.QuickCheck
 import Test.Syd
 
@@ -28,6 +31,31 @@ spec = doNotRandomiseExecutionOrder $ do
   it "takes at least 100 milliseconds (property) " $
     property $ \() -> do
       threadDelay 10_000
+  -- Ensure that long diff timeouts
+  -- See https://github.com/NorfairKing/sydtest/issues/92
+  it "long diff timing is bounded" $ do
+    -- with n = 1000 it takes 30s on my laptop, so 10k is enough to trigger the
+    -- 2s timeout.
+    let n = 10_0000
+    let test = do
+          res <- try $ sydTest $ do
+            it "test" $ do
+              let numbers = [0 :: Int, 1 .. n]
+                  numbers' = reverse numbers
+
+              numbers `shouldBe` numbers'
+
+          case res of
+            Right () -> fail "The subtest must fail"
+            Left (_ :: ExitCode) -> pure ()
+
+    -- We timeout after 10s. If the test timeouts by itself, it means that the
+    -- diff timeout worked after 2seconds.
+    --
+    -- Why 10s? Because it's more than 2s, and gives enough room for scheduling
+    -- and additional operations (such as generating the random numbers)
+    -- without too much risk of generating a flaky test.
+    timeout 10_000_000 test `shouldReturn` Just ()
 
 {-# NOINLINE take10ms #-}
 take10ms :: IO ()

--- a/sydtest/CHANGELOG.md
+++ b/sydtest/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+### Added
+
+- The test `Assertion` which displays a diff in case of error (so `shouldBe`, `shouldReturn`, golden tests and variations) will now timeout (after `2s`) when computing the diff between expected and actual value. In case of timeout, the values are displayed without any diff formatting. This ensure that test suite runtime won't be dominated by computing diff on some pathological cases. See https://github.com/NorfairKing/sydtest/issues/92
+- The smart constructor `mkNotEqualButShouldHaveBeenEqual` 
+- You can use your own diff algorithm using the constructor `NotEqualButShouldHaveBeenEqualWithDiff`.
+- Test suite does not crash if failed assertion trie to print values containing
+  lazy exception. For example `shouldBe (1, error "nop") (2, 3)` was crashing
+  sydTest, the exception is now reported as the failure reason for the test.
+  Note that this is counter intuitive, because the test is failing because
+  values are not equal (e.g. `(1, _) != (2, _)`), and this will be reported
+  differently.
+
+
+### Changed
+
+The diff computation between actual value and reference changed so diff can timeout. See See https://github.com/NorfairKing/sydtest/issues/92 for discussion.
+
+This does not change the usual API (`shouldBe` or `GoldenTest`), but some internal changed and you may need to adapt. The change is straightforward, most of the functions are not `IO`:
+
+- `stringsNotEqualButShouldHaveBeenEqual`, `textsNotEqualButShouldHaveBeenEqual` and `bytestringsNotEqualButShouldHaveBeenEqual` are now `IO Assertion` (was `Assertion`) in order to implement the timeout logic described for `shouldBe`
+- The `Assertion` `NotEqualButShouldHaveBeenEqual` is removed and replaced by `NotEqualButShouldHaveBeenEqualWithDiff` which embed the difference between both values.
+- the record field `goldenTestCompare` of `GoldenTest` changed from `a -> a ->
+  Maybe Assertion` to `a -> a -> IO (Maybe Assertion)`.
+
+
 ## [0.17.0.0] - 2024-08-04
 
 ### Changed

--- a/sydtest/default.nix
+++ b/sydtest/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, async, autodocodec, base, bytestring, containers
-, dlist, fast-myers-diff, filepath, lib, MonadRandom, mtl
+, deepseq, dlist, fast-myers-diff, filepath, lib, MonadRandom, mtl
 , opt-env-conf, path, path-io, pretty-show, QuickCheck
 , quickcheck-io, random, random-shuffle, safe, safe-coloured-text
 , safe-coloured-text-terminfo, stm, svg-builder, text, vector
@@ -9,9 +9,9 @@ mkDerivation {
   version = "0.17.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    async autodocodec base bytestring containers dlist fast-myers-diff
-    filepath MonadRandom mtl opt-env-conf path path-io pretty-show
-    QuickCheck quickcheck-io random random-shuffle safe
+    async autodocodec base bytestring containers deepseq dlist
+    fast-myers-diff filepath MonadRandom mtl opt-env-conf path path-io
+    pretty-show QuickCheck quickcheck-io random random-shuffle safe
     safe-coloured-text safe-coloured-text-terminfo stm svg-builder text
     vector
   ];

--- a/sydtest/package.yaml
+++ b/sydtest/package.yaml
@@ -29,7 +29,7 @@ library:
     - bytestring
     - containers
     - dlist
-    - fast-myers-diff
+    - fast-myers-diff >= 0.0.1
     - filepath
     - mtl
     - opt-env-conf >=0.5
@@ -45,6 +45,7 @@ library:
     - svg-builder
     - text
     - vector
+    - deepseq
   when:
     - condition: 'os(windows)'
       then:

--- a/sydtest/src/Test/Syd/Def/Golden.hs
+++ b/sydtest/src/Test/Syd/Def/Golden.hs
@@ -34,10 +34,11 @@ goldenByteStringFile fp produceBS =
         ensureDir $ parent resolvedFile
         SB.writeFile (fromAbsFile resolvedFile) actual,
       goldenTestCompare = \actual expected ->
-        pure $
-          if actual == expected
-            then Nothing
-            else Just $ Context (bytestringsNotEqualButShouldHaveBeenEqual actual expected) (goldenContext fp)
+        if actual == expected
+          then pure Nothing
+          else do
+            assertion <- bytestringsNotEqualButShouldHaveBeenEqual actual expected
+            pure $ Just $ Context assertion (goldenContext fp)
     }
 
 -- | Test that the given lazy bytestring is the same as what we find in the given golden file.
@@ -61,12 +62,13 @@ goldenLazyByteStringFile fp produceBS =
         ensureDir $ parent resolvedFile
         SB.writeFile (fromAbsFile resolvedFile) (LB.toStrict actual),
       goldenTestCompare = \actual expected ->
-        pure $
-          let actualBS = LB.toStrict actual
-              expectedBS = LB.toStrict expected
-           in if actualBS == expectedBS
-                then Nothing
-                else Just $ Context (bytestringsNotEqualButShouldHaveBeenEqual actualBS expectedBS) (goldenContext fp)
+        let actualBS = LB.toStrict actual
+            expectedBS = LB.toStrict expected
+         in if actualBS == expectedBS
+              then pure Nothing
+              else do
+                assertion <- bytestringsNotEqualButShouldHaveBeenEqual actualBS expectedBS
+                pure $ Just $ Context assertion (goldenContext fp)
     }
 
 -- | Test that the given lazy bytestring is the same as what we find in the given golden file.
@@ -90,12 +92,13 @@ goldenByteStringBuilderFile fp produceBS =
         ensureDir $ parent resolvedFile
         SB.writeFile (fromAbsFile resolvedFile) (LB.toStrict (SBB.toLazyByteString actual)),
       goldenTestCompare = \actual expected ->
-        pure $
-          let actualBS = LB.toStrict (SBB.toLazyByteString actual)
-              expectedBS = LB.toStrict (SBB.toLazyByteString expected)
-           in if actualBS == expectedBS
-                then Nothing
-                else Just $ Context (bytestringsNotEqualButShouldHaveBeenEqual actualBS expectedBS) (goldenContext fp)
+        let actualBS = LB.toStrict (SBB.toLazyByteString actual)
+            expectedBS = LB.toStrict (SBB.toLazyByteString expected)
+         in if actualBS == expectedBS
+              then pure Nothing
+              else do
+                assertion <- bytestringsNotEqualButShouldHaveBeenEqual actualBS expectedBS
+                pure $ Just $ Context assertion (goldenContext fp)
     }
 
 -- | Test that the given text is the same as what we find in the given golden file.
@@ -115,10 +118,11 @@ goldenTextFile fp produceBS =
         ensureDir $ parent resolvedFile
         SB.writeFile (fromAbsFile resolvedFile) (TE.encodeUtf8 actual),
       goldenTestCompare = \actual expected ->
-        pure $
-          if actual == expected
-            then Nothing
-            else Just $ Context (textsNotEqualButShouldHaveBeenEqual actual expected) (goldenContext fp)
+        if actual == expected
+          then pure Nothing
+          else do
+            assertion <- textsNotEqualButShouldHaveBeenEqual actual expected
+            pure $ Just $ Context assertion (goldenContext fp)
     }
 
 -- | Test that the given string is the same as what we find in the given golden file.
@@ -138,10 +142,11 @@ goldenStringFile fp produceBS =
         ensureDir $ parent resolvedFile
         SB.writeFile (fromAbsFile resolvedFile) (TE.encodeUtf8 (T.pack actual)),
       goldenTestCompare = \actual expected ->
-        pure $
-          if actual == expected
-            then Nothing
-            else Just $ Context (stringsNotEqualButShouldHaveBeenEqual actual expected) (goldenContext fp)
+        if actual == expected
+          then pure Nothing
+          else do
+            assertion <- stringsNotEqualButShouldHaveBeenEqual actual expected
+            pure $ Just $ Context assertion (goldenContext fp)
     }
 
 -- | Test that the show instance has not changed for the given value.

--- a/sydtest/src/Test/Syd/Expectation.hs
+++ b/sydtest/src/Test/Syd/Expectation.hs
@@ -11,20 +11,25 @@ import Control.Exception
 #if MIN_VERSION_mtl(2,3,0)
 import Control.Monad (unless, when)
 #endif
+import Control.DeepSeq (force)
 import Control.Monad.Reader
 import Data.ByteString (ByteString)
 import Data.List
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Typeable
+import qualified Data.Vector as V
 import GHC.Stack
+import Myers.Diff (Diff, getTextDiff)
+import System.Timeout (timeout)
 import Test.QuickCheck.IO ()
 import Test.Syd.Run
+import Text.Colour (Chunk)
 import Text.Show.Pretty
 
 -- | Assert that two values are equal according to `==`.
 shouldBe :: (HasCallStack, Show a, Eq a) => a -> a -> IO ()
-shouldBe actual expected = unless (actual == expected) $ throwIO $ NotEqualButShouldHaveBeenEqual (ppShow actual) (ppShow expected)
+shouldBe actual expected = unless (actual == expected) $ throwIO =<< mkNotEqualButShouldHaveBeenEqual actual expected
 
 infix 1 `shouldBe`
 
@@ -58,7 +63,7 @@ shouldNotSatisfyNamed actual name p = when (p actual) $ throwIO $ PredicateSucce
 shouldReturn :: (HasCallStack, Show a, Eq a) => IO a -> a -> IO ()
 shouldReturn computeActual expected = do
   actual <- computeActual
-  unless (actual == expected) $ throwIO $ NotEqualButShouldHaveBeenEqual (ppShow actual) (ppShow expected)
+  unless (actual == expected) $ throwIO =<< mkNotEqualButShouldHaveBeenEqual actual expected
 
 infix 1 `shouldReturn`
 
@@ -100,32 +105,32 @@ shouldMatchList a b = shouldSatisfyNamed a ("matches list\n" <> ppShow b) (match
 -- Note that using function could mess up the colours in your terminal if the Texts contain ANSI codes.
 -- In that case you may want to `show` your values first or use `shouldBe` instead.
 stringShouldBe :: (HasCallStack) => String -> String -> IO ()
-stringShouldBe actual expected = unless (actual == expected) $ throwIO $ stringsNotEqualButShouldHaveBeenEqual actual expected
+stringShouldBe actual expected = unless (actual == expected) $ throwIO =<< stringsNotEqualButShouldHaveBeenEqual actual expected
 
 -- | Assert that two 'Text's are equal according to `==`.
 --
 -- Note that using function could mess up the colours in your terminal if the Texts contain ANSI codes.
 -- In that case you may want to `show` your values first or use `shouldBe` instead.
 textShouldBe :: (HasCallStack) => Text -> Text -> IO ()
-textShouldBe actual expected = unless (actual == expected) $ throwIO $ textsNotEqualButShouldHaveBeenEqual actual expected
+textShouldBe actual expected = unless (actual == expected) $ throwIO =<< textsNotEqualButShouldHaveBeenEqual actual expected
 
 -- | An assertion that says two 'String's should have been equal according to `==`.
 --
 -- Note that using function could mess up the colours in your terminal if the Texts contain ANSI codes.
 -- In that case you may want to `show` your values first or use `shouldBe` instead.
-stringsNotEqualButShouldHaveBeenEqual :: String -> String -> Assertion
-stringsNotEqualButShouldHaveBeenEqual actual expected = NotEqualButShouldHaveBeenEqual actual expected
+stringsNotEqualButShouldHaveBeenEqual :: String -> String -> IO Assertion
+stringsNotEqualButShouldHaveBeenEqual actual expected = mkNotEqualButShouldHaveBeenEqual actual expected
 
 -- | An assertion that says two 'Text's should have been equal according to `==`.
 --
 -- Note that using function could mess up the colours in your terminal if the Texts contain ANSI codes.
 -- In that case you may want to `show` your values first or use `shouldBe` instead.
-textsNotEqualButShouldHaveBeenEqual :: Text -> Text -> Assertion
-textsNotEqualButShouldHaveBeenEqual actual expected = NotEqualButShouldHaveBeenEqual (T.unpack actual) (T.unpack expected)
+textsNotEqualButShouldHaveBeenEqual :: Text -> Text -> IO Assertion
+textsNotEqualButShouldHaveBeenEqual actual expected = mkNotEqualButShouldHaveBeenEqual (T.unpack actual) (T.unpack expected)
 
 -- | An assertion that says two 'ByteString's should have been equal according to `==`.
-bytestringsNotEqualButShouldHaveBeenEqual :: ByteString -> ByteString -> Assertion
-bytestringsNotEqualButShouldHaveBeenEqual actual expected = NotEqualButShouldHaveBeenEqual (show actual) (show expected)
+bytestringsNotEqualButShouldHaveBeenEqual :: ByteString -> ByteString -> IO Assertion
+bytestringsNotEqualButShouldHaveBeenEqual actual expected = mkNotEqualButShouldHaveBeenEqual (show actual) (show expected)
 
 -- | Make a test fail
 --

--- a/sydtest/sydtest.cabal
+++ b/sydtest/sydtest.cabal
@@ -66,8 +66,9 @@ library
     , base >=4.7 && <5
     , bytestring
     , containers
+    , deepseq
     , dlist
-    , fast-myers-diff
+    , fast-myers-diff >=0.0.1
     , filepath
     , mtl
     , opt-env-conf >=0.5

--- a/test_resources/defaultSettings-show.golden
+++ b/test_resources/defaultSettings-show.golden
@@ -1,0 +1,19 @@
+Settings
+  { settingSeed = FixedSeed 42
+  , settingRandomiseExecutionOrder = True
+  , settingThreads = ByCapabilities
+  , settingMaxSuccess = 100
+  , settingMaxSize = 100
+  , settingMaxDiscard = 10
+  , settingMaxShrinks = 100
+  , settingGoldenStart = False
+  , settingGoldenReset = False
+  , settingColour = Nothing
+  , settingFilters = []
+  , settingFailFast = False
+  , settingIterations = OneIteration
+  , settingRetries = 3
+  , settingFailOnFlaky = False
+  , settingReportProgress = ReportNoProgress
+  , settingProfile = False
+  }

--- a/test_resources/documentation.txt
+++ b/test_resources/documentation.txt
@@ -1,0 +1,286 @@
+[36mUsage: [m[33msydtest[m [36m[[m[37m--config-file[m [33mFILE_PATH[m[36m][m [36m[[m[37m--random-seed[m [36m|[m [37m--seed[m [33mINT[m[36m][m [36m[[m[37m--[no-]randomise-execution-order[m[36m|[m[37m--[no-]randomize-execution-order[m[36m][m [36m[[m[37m--jobs[m[36m|[m[37m--threads[m [33mINT[m [36m|[m [37m--synchronous[m[36m][m [36m[[m[37m--max-size[m [33mInt[m[36m][m [36m[[m[37m--max-success[m [33mInt[m[36m][m [36m[[m[37m--max-discard[m [33mInt[m[36m][m [36m[[m[37m--max-shrinks[m [33mInt[m[36m][m [36m[[m[37m--[no-]golden-start[m[36m][m [36m[[m[37m--[no-]golden-reset[m[36m][m [36m[[m[37m--[no-]colour[m[36m|[m[37m--[no-]color[m[36m][m [36m[[m[33mFILTER[m [36m[[m[33mFILTER[m[36m][m [36m|[m [37m-f[m[36m|[m[37m--filter[m[36m|[m[37m-m[m[36m|[m[37m--match[m [33mFILTER[m[36m][m [36m[[m[37m--[no-]fail-fast[m[36m][m [36m[[m[37m--continuous[m [36m|[m [37m--iterations[m [33mINT[m[36m][m [36m[[m[37m--retries[m [33mINTEGER[m[36m][m [36m[[m[37m--[no-]fail-on-flaky[m[36m][m [36m[[m[37m--progress[m [36m|[m [37m--no-progress[m[36m][m [36m[[m[37m--[no-]debug[m[36m][m [36m[[m[37m--[no-]profile[m[36m][m
+
+[36mAll settings[m:
+  [34mShow this help text[m
+  switch: [37m-h[m[36m|[m[37m--help[m
+
+  [34mOutput version information[m
+  switch: [37m--version[m
+
+  [34mPath to the configuration file[m
+  option: [37m--config-file[m [33mFILE_PATH[m
+  env: [37mSYDTEST_CONFIG_FILE[m [33mFILE_PATH[m
+
+  [34mUse a random seed for pseudo-randomness[m
+  switch: [37m--random-seed[m
+  env: [37mSYDTEST_RANDOM_SEED[m [33mANY[m
+
+  [34mSeed for pseudo-randomness[m
+  option: [37m--seed[m [33mINT[m
+  env: [37mSYDTEST_SEED[m [33mINT[m
+  config:
+    [37mseed[m: # [32many of[m
+      [ [33mnull[m
+      , random
+      , [33m<integer>[m # [32m64 bit signed integer[m
+      ]
+
+  [34mRun test suite in a random order[m
+  switch: [37m--[no-]randomise-execution-order[m[36m|[m[37m--[no-]randomize-execution-order[m
+  env: [37mSYDTEST_RANDOMISE_EXECUTION_ORDER[m[36m|[m[37mSYDTEST_RANDOMIZE_EXECUTION_ORDER[m [33mBOOL[m
+  config:
+    [37mrandomise-execution-order[m: # [32mor null[m
+      [33m<boolean>[m
+  config:
+    [37mrandomize-execution-order[m: # [32mor null[m
+      [33m<boolean>[m
+
+  [34mHow many threads to use to execute tests in asynchrnously[m
+  option: [37m--jobs[m[36m|[m[37m--threads[m [33mINT[m
+  env: [37mSYDTEST_JOBS[m[36m|[m[37mSYDTEST_THREADS[m [33mINT[m
+
+  [34mUse only one thread, to execute tests synchronously[m
+  switch: [37m--synchronous[m
+  env: [37mSYDTEST_SYNCHRONOUS[m [33mANY[m
+
+  [34mHow parallel to run the test suite[m
+  config:
+    [37mthreads[m: # [32mor null[m
+      [33m<integer>[m # [32m64 bit unsigned integer[m
+
+  [34mMaximum size parameter to pass to generators[m
+  option: [37m--max-size[m [33mInt[m
+  env: [37mSYDTEST_MAX_SIZE[m [33mInt[m
+  config:
+    [37mmax-size[m: # [32mor null[m
+      [33m<integer>[m # [32m64 bit signed integer[m
+  default: [33m100[m
+
+  [34mNumber of property test examples to run[m
+  option: [37m--max-success[m [33mInt[m
+  env: [37mSYDTEST_MAX_SUCCESS[m [33mInt[m
+  config:
+    [37mmax-success[m: # [32mor null[m
+      [33m<integer>[m # [32m64 bit signed integer[m
+  default: [33m100[m
+
+  [34mMaximum number of property test inputs to discard before considering the test failed[m
+  option: [37m--max-discard[m [33mInt[m
+  env: [37mSYDTEST_MAX_DISCARD[m [33mInt[m
+  config:
+    [37mmax-discard[m: # [32mor null[m
+      [33m<integer>[m # [32m64 bit signed integer[m
+  default: [33m10[m
+
+  [34mMaximum shrinks to try to apply to a failing property test input[m
+  option: [37m--max-shrinks[m [33mInt[m
+  env: [37mSYDTEST_MAX_SHRINKS[m [33mInt[m
+  config:
+    [37mmax-shrinks[m: # [32mor null[m
+      [33m<integer>[m # [32m64 bit signed integer[m
+  default: [33m100[m
+
+  [34mProduce initial golden output if it does not exist yet[m
+  switch: [37m--[no-]golden-start[m
+  env: [37mSYDTEST_GOLDEN_START[m [33mBOOL[m
+  config:
+    [37mgolden-start[m: # [32mor null[m
+      [33m<boolean>[m
+
+  [34mOverwrite golden output[m
+  switch: [37m--[no-]golden-reset[m
+  env: [37mSYDTEST_GOLDEN_RESET[m [33mBOOL[m
+  config:
+    [37mgolden-reset[m: # [32mor null[m
+      [33m<boolean>[m
+
+  [34mUse colour in output[m
+  switch: [37m--[no-]colour[m[36m|[m[37m--[no-]color[m
+  env: [37mSYDTEST_COLOUR[m[36m|[m[37mSYDTEST_COLOR[m [33mBOOL[m
+  config:
+    [37mcolour[m: # [32mor null[m
+      [33m<boolean>[m
+  config:
+    [37mcolor[m: # [32mor null[m
+      [33m<boolean>[m
+
+  [34mFilter to select parts of the test suite[m
+  argument: [33mFILTER[m
+
+  [34mFilter to select parts of the test suite[m
+  argument: [33mFILTER[m
+
+  [34mFilter to select parts of the test suite[m
+  option: [37m-f[m[36m|[m[37m--filter[m[36m|[m[37m-m[m[36m|[m[37m--match[m [33mFILTER[m
+
+  [34mStop testing when a test failure occurs[m
+  switch: [37m--[no-]fail-fast[m
+  env: [37mSYDTEST_FAIL_FAST[m [33mBOOL[m
+  config:
+    [37mfail-fast[m: # [32mor null[m
+      [33m<boolean>[m
+
+  [34mRun the test suite over and over again until it fails, for example to diagnose flakiness[m
+  switch: [37m--continuous[m
+
+  [34mHow many iterations of the suite to run, for example to diagnose flakiness[m
+  option: [37m--iterations[m [33mINT[m
+
+  [34mThe number of retries to use for flakiness diagnostics. 0 means 'no retries'[m
+  option: [37m--retries[m [33mINTEGER[m
+  env: [37mSYDTEST_RETRIES[m [33mINTEGER[m
+  config:
+    [37mretries[m: # [32mor null[m
+      [33m<integer>[m # [32m64 bit unsigned integer[m
+
+  [34mFail when any flakiness is detected, even when flakiness is allowed[m
+  switch: [37m--[no-]fail-on-flaky[m
+  env: [37mSYDTEST_FAIL_ON_FLAKY[m [33mBOOL[m
+  config:
+    [37mfail-on-flaky[m: # [32mor null[m
+      [33m<boolean>[m
+
+  [34mReport per-example progress[m
+  switch: [37m--progress[m
+
+  [34mDon't report per-example progress[m
+  switch: [37m--no-progress[m
+
+  [34mTurn on debug mode[m
+  switch: [37m--[no-]debug[m
+  env: [37mSYDTEST_DEBUG[m [33mBOOL[m
+  config:
+    [37mdebug[m: # [32mor null[m
+      [33m<boolean>[m
+
+  [34mTurn on profiling mode[m
+  switch: [37m--[no-]profile[m
+  env: [37mSYDTEST_PROFILE[m [33mBOOL[m
+  config:
+    [37mprofile[m: # [32mor null[m
+      [33m<boolean>[m
+
+[36mOptions[m:
+  [37m-h[m[36m|[m[37m--help[m                                                         [34mShow this help text[m                                                                                  
+  [37m--version[m                                                         [34mOutput version information[m                                                                           
+  [37m--config-file[m                                                     [34mPath to the configuration file[m                                                                       
+  [37m--random-seed[m                                                     [34mUse a random seed for pseudo-randomness[m                                                              
+  [37m--seed[m                                                            [34mSeed for pseudo-randomness[m                                                                           
+  [37m--[no-]randomise-execution-order[m[36m|[m[37m--[no-]randomize-execution-order[m [34mRun test suite in a random order[m                                                                     
+  [37m--jobs[m[36m|[m[37m--threads[m                                                  [34mHow many threads to use to execute tests in asynchrnously[m                                            
+  [37m--synchronous[m                                                     [34mUse only one thread, to execute tests synchronously[m                                                  
+  [37m--max-size[m                                                        [34mMaximum size parameter to pass to generators[m                                             default: [33m100[m
+  [37m--max-success[m                                                     [34mNumber of property test examples to run[m                                                  default: [33m100[m
+  [37m--max-discard[m                                                     [34mMaximum number of property test inputs to discard before considering the test failed[m     default: [33m10[m 
+  [37m--max-shrinks[m                                                     [34mMaximum shrinks to try to apply to a failing property test input[m                         default: [33m100[m
+  [37m--[no-]golden-start[m                                               [34mProduce initial golden output if it does not exist yet[m                                               
+  [37m--[no-]golden-reset[m                                               [34mOverwrite golden output[m                                                                              
+  [37m--[no-]colour[m[36m|[m[37m--[no-]color[m                                        [34mUse colour in output[m                                                                                 
+  [33mFILTER[m                                                            [34mFilter to select parts of the test suite[m                                                             
+  [33mFILTER[m                                                            [34mFilter to select parts of the test suite[m                                                             
+  [37m-f[m[36m|[m[37m--filter[m[36m|[m[37m-m[m[36m|[m[37m--match[m                                            [34mFilter to select parts of the test suite[m                                                             
+  [37m--[no-]fail-fast[m                                                  [34mStop testing when a test failure occurs[m                                                              
+  [37m--continuous[m                                                      [34mRun the test suite over and over again until it fails, for example to diagnose flakiness[m             
+  [37m--iterations[m                                                      [34mHow many iterations of the suite to run, for example to diagnose flakiness[m                           
+  [37m--retries[m                                                         [34mThe number of retries to use for flakiness diagnostics. 0 means 'no retries'[m                         
+  [37m--[no-]fail-on-flaky[m                                              [34mFail when any flakiness is detected, even when flakiness is allowed[m                                  
+  [37m--progress[m                                                        [34mReport per-example progress[m                                                                          
+  [37m--no-progress[m                                                     [34mDon't report per-example progress[m                                                                    
+  [37m--[no-]debug[m                                                      [34mTurn on debug mode[m                                                                                   
+  [37m--[no-]profile[m                                                    [34mTurn on profiling mode[m                                                                               
+
+[36mEnvironment Variables[m:
+  [37mSYDTEST_CONFIG_FILE[m [33mFILE_PATH[m                                              [34mPath to the configuration file[m                                                                     
+  [37mSYDTEST_RANDOM_SEED[m [33mANY[m                                                    [34mUse a random seed for pseudo-randomness[m                                                            
+  [37mSYDTEST_SEED[m [33mINT[m                                                           [34mSeed for pseudo-randomness[m                                                                         
+  [37mSYDTEST_RANDOMISE_EXECUTION_ORDER[m[36m|[m[37mSYDTEST_RANDOMIZE_EXECUTION_ORDER[m [33mBOOL[m   [34mRun test suite in a random order[m                                                                   
+  [37mSYDTEST_JOBS[m[36m|[m[37mSYDTEST_THREADS[m [33mINT[m                                           [34mHow many threads to use to execute tests in asynchrnously[m                                          
+  [37mSYDTEST_SYNCHRONOUS[m [33mANY[m                                                    [34mUse only one thread, to execute tests synchronously[m                                                
+  [37mSYDTEST_MAX_SIZE[m [33mInt[m                                                       [34mMaximum size parameter to pass to generators[m                                           default: [33m100[m
+  [37mSYDTEST_MAX_SUCCESS[m [33mInt[m                                                    [34mNumber of property test examples to run[m                                                default: [33m100[m
+  [37mSYDTEST_MAX_DISCARD[m [33mInt[m                                                    [34mMaximum number of property test inputs to discard before considering the test failed[m   default: [33m10[m 
+  [37mSYDTEST_MAX_SHRINKS[m [33mInt[m                                                    [34mMaximum shrinks to try to apply to a failing property test input[m                       default: [33m100[m
+  [37mSYDTEST_GOLDEN_START[m [33mBOOL[m                                                  [34mProduce initial golden output if it does not exist yet[m                                             
+  [37mSYDTEST_GOLDEN_RESET[m [33mBOOL[m                                                  [34mOverwrite golden output[m                                                                            
+  [37mSYDTEST_COLOUR[m[36m|[m[37mSYDTEST_COLOR[m [33mBOOL[m                                          [34mUse colour in output[m                                                                               
+  [37mSYDTEST_FAIL_FAST[m [33mBOOL[m                                                     [34mStop testing when a test failure occurs[m                                                            
+  [37mSYDTEST_RETRIES[m [33mINTEGER[m                                                    [34mThe number of retries to use for flakiness diagnostics. 0 means 'no retries'[m                       
+  [37mSYDTEST_FAIL_ON_FLAKY[m [33mBOOL[m                                                 [34mFail when any flakiness is detected, even when flakiness is allowed[m                                
+  [37mSYDTEST_DEBUG[m [33mBOOL[m                                                         [34mTurn on debug mode[m                                                                                 
+  [37mSYDTEST_PROFILE[m [33mBOOL[m                                                       [34mTurn on profiling mode[m                                                                             
+
+[36mConfiguration Values[m:
+  [34mSeed for pseudo-randomness[m
+  [37mseed[m:
+    # [32many of[m
+    [ [33mnull[m
+    , random
+    , [33m<integer>[m # [32m64 bit signed integer[m
+    ]
+  [34mRun test suite in a random order[m
+  [37mrandomise-execution-order[m:
+    # [32mor null[m
+    [33m<boolean>[m
+  [37mrandomize-execution-order[m:
+    # [32mor null[m
+    [33m<boolean>[m
+  [34mHow parallel to run the test suite[m
+  [37mthreads[m:
+    # [32mor null[m
+    [33m<integer>[m # [32m64 bit unsigned integer[m
+  [34mMaximum size parameter to pass to generators[m
+  default: [33m100[m
+  [37mmax-size[m:
+    # [32mor null[m
+    [33m<integer>[m # [32m64 bit signed integer[m
+  [34mNumber of property test examples to run[m
+  default: [33m100[m
+  [37mmax-success[m:
+    # [32mor null[m
+    [33m<integer>[m # [32m64 bit signed integer[m
+  [34mMaximum number of property test inputs to discard before considering the test failed[m
+  default: [33m10[m
+  [37mmax-discard[m:
+    # [32mor null[m
+    [33m<integer>[m # [32m64 bit signed integer[m
+  [34mMaximum shrinks to try to apply to a failing property test input[m
+  default: [33m100[m
+  [37mmax-shrinks[m:
+    # [32mor null[m
+    [33m<integer>[m # [32m64 bit signed integer[m
+  [34mProduce initial golden output if it does not exist yet[m
+  [37mgolden-start[m:
+    # [32mor null[m
+    [33m<boolean>[m
+  [34mOverwrite golden output[m
+  [37mgolden-reset[m:
+    # [32mor null[m
+    [33m<boolean>[m
+  [34mUse colour in output[m
+  [37mcolour[m:
+    # [32mor null[m
+    [33m<boolean>[m
+  [37mcolor[m:
+    # [32mor null[m
+    [33m<boolean>[m
+  [34mStop testing when a test failure occurs[m
+  [37mfail-fast[m:
+    # [32mor null[m
+    [33m<boolean>[m
+  [34mThe number of retries to use for flakiness diagnostics. 0 means 'no retries'[m
+  [37mretries[m:
+    # [32mor null[m
+    [33m<integer>[m # [32m64 bit unsigned integer[m
+  [34mFail when any flakiness is detected, even when flakiness is allowed[m
+  [37mfail-on-flaky[m:
+    # [32mor null[m
+    [33m<boolean>[m
+  [34mTurn on debug mode[m
+  [37mdebug[m:
+    # [32mor null[m
+    [33m<boolean>[m
+  [34mTurn on profiling mode[m
+  [37mprofile[m:
+    # [32mor null[m
+    [33m<boolean>[m
+

--- a/test_resources/output-test.txt
+++ b/test_resources/output-test.txt
@@ -1,0 +1,907 @@
+[34mTests:[m
+
+[32m✓ [m[32mPasses[m                                                                            [32m      0.00 ms[m
+[33merror[m
+  [31m✗ [m[31mPure error[m                                                                      [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mImpure error[m                                                                    [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+[33mundefined[m
+  [31m✗ [m[31mPure undefined[m                                                                  [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mImpure undefined[m                                                                [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+[31m✗ [m[31mExit code[m                                                                         [32m      0.00 ms[m
+  Retries: 3 (does not look flaky)
+[33mexceptions[m
+  [31m✗ [m[31mRecord construction error[m                                                       [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [33mRecord construction error[m
+    [31m✗ [m[31mfails in IO, as the result[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in IO, as the action[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in pure code[m                                                            [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [31m✗ [m[31mRecord selection error[m                                                          [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [33mRecord selection error[m
+    [31m✗ [m[31mfails in IO, as the result[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in IO, as the action[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in pure code[m                                                            [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [31m✗ [m[31mRecord update error[m                                                             [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [33mRecord update error[m
+    [31m✗ [m[31mfails in IO, as the result[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in IO, as the action[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in pure code[m                                                            [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [31m✗ [m[31mPattern matching error[m                                                          [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [33mPattern matching error[m
+    [31m✗ [m[31mfails in IO, as the result[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in IO, as the action[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in pure code[m                                                            [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [31m✗ [m[31mArithException[m                                                                  [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [33mPattern matching error[m
+    [31m✗ [m[31mfails in IO, as the result[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in IO, as the action[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in pure code[m                                                            [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [31m✗ [m[31mNoMethodError[m                                                                   [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [33mPattern matching error[m
+    [31m✗ [m[31mfails in IO, as the result[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in IO, as the action[m                                                    [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mfails in pure code[m                                                            [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+[33mPrinting[m
+  [32m✓ [m[32mprint[m                                                                           [32m      0.00 ms[m
+  [32m✓ [m[32mputStrLn[m                                                                        [32m      0.00 ms[m
+[33mProperty tests[m
+  [33mpure[m
+    [32m✓ [m[32mreversing a list twice is the same as reversing it once[m                       [32m      0.00 ms[m
+      passed for all of [32m10[m inputs.
+    [31m✗ [m[31mshould fail to show that sorting does nothing[m                                 [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [32m✓ [m[32mshould work with custom generators too[m                                        [32m      0.00 ms[m
+      passed for all of [32m10[m inputs.
+  [33mimpure[m
+    [32m✓ [m[32mreversing a list twice is the same as reversing it once[m                       [32m      0.00 ms[m
+      passed for all of [32m10[m inputs.
+    [31m✗ [m[31mshould fail to show that sorting does nothing[m                                 [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [32m✓ [m[32mshould work with custom generators too[m                                        [32m      0.00 ms[m
+      passed for all of [32m10[m inputs.
+[33mLong running tests[m
+  [32m✓ [m[32mtakes a while (1)[m                                                               [32m      0.00 ms[m
+  [32m✓ [m[32mtakes a while (2)[m                                                               [32m      0.00 ms[m
+  [32m✓ [m[32mtakes a while (3)[m                                                               [32m      0.00 ms[m
+  [32m✓ [m[32mtakes a while (4)[m                                                               [32m      0.00 ms[m
+  [32m✓ [m[32mtakes a while (5)[m                                                               [32m      0.00 ms[m
+  [32m✓ [m[32mtakes a while (6)[m                                                               [32m      0.00 ms[m
+  [32m✓ [m[32mtakes a while (7)[m                                                               [32m      0.00 ms[m
+  [32m✓ [m[32mtakes a while (8)[m                                                               [32m      0.00 ms[m
+  [32m✓ [m[32mtakes a while (9)[m                                                               [32m      0.00 ms[m
+  [32m✓ [m[32mtakes a while (10)[m                                                              [32m      0.00 ms[m
+[33mDiff[m
+  [31m✗ [m[31mshows nice multi-line diffs[m                                                     [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mshows nice multi-line diffs[m                                                     [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+[33massertions[m
+  [31m✗ [m[31mshouldBe[m                                                                        [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mshouldNotBe[m                                                                     [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mshouldSatisfy[m                                                                   [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mshouldNotSatisfy[m                                                                [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mshouldSatisfyNamed[m                                                              [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mshouldNotSatisfyNamed[m                                                           [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+[35mpending test[m
+[33mGolden[m
+  [31m✗ [m[31mdoes not fail the suite when an exception happens while reading[m                 [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mdoes not fail the suite when an exception happens while producing[m               [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mdoes not fail the suite when an exception happens while writing[m                 [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mdoes not fail the suite when an exception happens while checking for equality[m   [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [33moutputResultForest[m
+    [32m✓ [m[32moutputs the same as last time[m                                                 [32m      0.00 ms[m
+[33mAround[m
+  [33mbefore[m
+    [31m✗ [m[31mdoes not kill the test suite[m                                                  [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [33mbefore_[m
+    [31m✗ [m[31mdoes not kill the test suite[m                                                  [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [33mafter[m
+    [31m✗ [m[31mdoes not kill the test suite[m                                                  [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [33mafter_[m
+    [31m✗ [m[31mdoes not kill the test suite[m                                                  [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [33maround[m
+    [31m✗ [m[31mdoes not kill the test suite[m                                                  [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [33maround_[m
+    [31m✗ [m[31mdoes not kill the test suite[m                                                  [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [33maroundWith[m
+    [31m✗ [m[31mdoes not kill the test suite[m                                                  [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [33maroundWith'[m
+    [31m✗ [m[31mdoes not kill the test suite[m                                                  [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+[31m✗ [m[31mexpectationFailure[m                                                                [32m      0.00 ms[m
+  Retries: 3 (does not look flaky)
+[33mString[m
+  [31m✗ [m[31mcompares strings[m                                                                [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mcompares strings[m                                                                [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mcompares texts[m                                                                  [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mcompares texts[m                                                                  [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mcompares bytestrings[m                                                            [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+[33mContext[m
+  [31m✗ [m[31mshows a nice context[m                                                            [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mshows a nice context multiple levels deep[m                                       [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mshows a context when an exception is thrown as well[m                             [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+[33mProperty[m
+  [33m0 tests run[m
+    [32m✓ [m[32mshows a red '0 tests' when no tests are run[m                                   [32m      0.00 ms[m
+      passed for all of [31m0[m inputs.
+  [33mgenerated values[m
+    [31m✗ [m[31mshows many generated values too[m                                               [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+  [33mlabels[m
+    [32m✓ [m[32mshows the labels in use on success[m                                            [32m      0.00 ms[m
+      passed for all of [32m100[m inputs.
+      Labels
+        31.00% "length of input is 0"
+        21.00% "length of input is 1"
+        13.00% "length of input is 2"
+         8.00% "length of input is 3"
+         6.00% "length of input is 4"
+        10.00% "length of input is 5"
+         6.00% "length of input is 6"
+         4.00% "length of input is 7"
+         1.00% "length of input is 8"
+    [32m✓ [m[32mshows the labels in use on success[m                                            [32m      0.00 ms[m
+      passed for all of [32m100[m inputs.
+      Labels
+        31.00% "length of input is 0", "magnitude (digits) of sum of input is 0"
+        13.00% "length of input is 1", "magnitude (digits) of sum of input is 0"
+         8.00% "length of input is 1", "magnitude (digits) of sum of input is 1"
+         5.00% "length of input is 2", "magnitude (digits) of sum of input is 0"
+         7.00% "length of input is 2", "magnitude (digits) of sum of input is 1"
+         1.00% "length of input is 2", "magnitude (digits) of sum of input is 2"
+         4.00% "length of input is 3", "magnitude (digits) of sum of input is 0"
+         3.00% "length of input is 3", "magnitude (digits) of sum of input is 1"
+         1.00% "length of input is 3", "magnitude (digits) of sum of input is 2"
+         5.00% "length of input is 4", "magnitude (digits) of sum of input is 0"
+         1.00% "length of input is 4", "magnitude (digits) of sum of input is 2"
+         7.00% "length of input is 5", "magnitude (digits) of sum of input is 0"
+         3.00% "length of input is 5", "magnitude (digits) of sum of input is 2"
+         5.00% "length of input is 6", "magnitude (digits) of sum of input is 0"
+         1.00% "length of input is 6", "magnitude (digits) of sum of input is 2"
+         2.00% "length of input is 7", "magnitude (digits) of sum of input is 0"
+         2.00% "length of input is 7", "magnitude (digits) of sum of input is 1"
+         1.00% "length of input is 8", "magnitude (digits) of sum of input is 0"
+    [31m✗ [m[31mshows the labels in use on failure[m                                            [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+      Labels
+        100.00% "length of input is 0", "magnitude (digits) of sum of input is 0"
+  [33mclasses[m
+    [32m✓ [m[32mshows the classes in use on success[m                                           [32m      0.00 ms[m
+      passed for all of [32m100[m inputs.
+      Classes
+        100.00% non-trivial
+    [32m✓ [m[32mshows the classes in use on success[m                                           [32m      0.00 ms[m
+      passed for all of [32m100[m inputs.
+      Classes
+        31.00% empty
+        48.00% non-trivial
+        21.00% single element
+    [31m✗ [m[31mshows the classes in use on failure[m                                           [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+      Classes
+        100.00% empty
+  [33mtables[m
+    [32m✓ [m[32mshows the tables in use on success[m                                            [32m      0.00 ms[m
+      passed for all of [32m100[m inputs.
+       
+      List elements
+        10.14% -1
+         6.45% -2
+         7.37% -3
+         7.83% -4
+         5.07% -5
+         4.61% -6
+         5.99% -7
+         1.38% -8
+         0.46% -9
+         7.37% 0
+         6.91% 1
+         6.45% 2
+         6.45% 3
+         6.45% 4
+         4.61% 5
+         4.61% 6
+         4.61% 7
+         1.84% 8
+         1.38% 9
+[33mShrinking[m
+  [31m✗ [m[31mcan grab the mvar during shrinking[m                                              [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+[33mRetries[m
+  [31m✗ [m[31mdoes not retry if the test is configured withoutRetries[m                         [32m      0.00 ms[m
+  [31m✗ [m[31mRetries this five times[m                                                         [32m      0.00 ms[m
+    Retries: 5 (does not look flaky)
+[33mFlakiness[m
+  [32m✓ [m[32mAllows flakiness on True eventhough there is none (should succeed)[m              [32m      0.00 ms[m
+  [31m✗ [m[31mAllows flakiness on False eventhough there is none (should fail)[m                [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [32m✓ [m[32mallows this intentionally flaky test with the default number of retries[m         [32m      0.00 ms[m
+    Retries: 2[31m !!! FLAKY !!![m
+    [35mWe're on it![m
+  [31m✗ [m[31mDoes not allow flakiness if flakiness is not allowed even if retries happen[m     [32m      0.00 ms[m
+    Retries: 2[31m !!! FLAKY !!![m
+  [31m✗ [m[31mAllows flakiness in this boolean five times (should fail with 5 retries)[m        [32m      0.00 ms[m
+    Retries: 5 (does not look flaky)
+  [32m✓ [m[32mallows this intentionally flaky test with up to four retries[m                    [32m      0.00 ms[m
+    Retries: 2[31m !!! FLAKY !!![m
+    [35mWe're on it![m
+[33mxdescribe[m
+  [33mtwo pending tests below here[m
+    [35mone[m
+    [35mtwo[m
+  [33mfour pending tests below here[m
+    [35mone[m
+    [35mtwo[m
+    [33mwat[m
+      [35mthree[m
+      [35mfour[m
+[33mcallstack[m
+  [31m✗ [m[31mit[m                                                                              [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mspecify[m                                                                         [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mprop[m                                                                            [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [33mdescribe[m
+    [31m✗ [m[31mdescribe-it[m                                                                   [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+    [31m✗ [m[31mdescribe-specify[m                                                              [32m      0.00 ms[m
+      Retries: 3 (does not look flaky)
+[33mexpectations[m
+  [32m✓ [m[32mconsidered passing[m                                                              [32m      0.00 ms[m
+  [32m✓ [m[32mconsidered passing[m                                                              [32m      0.00 ms[m
+  [31m✗ [m[31mconsidered failing[m                                                              [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mconsidered failing[m                                                              [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+[33mcombinators[m
+  [31m✗ [m[31mshould fail[m                                                                     [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [32m✓ [m[32mshould pass[m                                                                     [32m      0.00 ms[m
+    passed for all of [32m100[m inputs.
+  [31m✗ [m[31mshould not crash (undefined value)[m                                              [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mshould not crash (undefined generator)[m                                          [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [31m✗ [m[31mshould be even[m                                                                  [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+  [32m✓ [m[32mshould be even[m                                                                  [32m      0.00 ms[m
+  [31m✗ [m[31mshould be even[m                                                                  [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+[33mrandomness[m
+  [31m✗ [m[31malways outputs the same pseudorandomness[m                                        [32m      0.00 ms[m
+    Retries: 3 (does not look flaky)
+
+
+[34mFailures:[m
+
+  [36m  output-test/Spec.hs:35[m
+  [31m✗ [m[31m1 [m[31merror.Pure error[m
+       Retries: 3 (does not look flaky)
+       foobar
+       CallStack (from HasCallStack):
+         error, called at output-test/Spec.hs:35:28 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
+  
+  [36m  output-test/Spec.hs:36[m
+  [31m✗ [m[31m2 [m[31merror.Impure error[m
+       Retries: 3 (does not look flaky)
+       foobar
+       CallStack (from HasCallStack):
+         error, called at output-test/Spec.hs:36:24 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
+  
+  [36m  output-test/Spec.hs:38[m
+  [31m✗ [m[31m3 [m[31mundefined.Pure undefined[m
+       Retries: 3 (does not look flaky)
+       Prelude.undefined
+       CallStack (from HasCallStack):
+         undefined, called at output-test/Spec.hs:38:31 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
+  
+  [36m  output-test/Spec.hs:39[m
+  [31m✗ [m[31m4 [m[31mundefined.Impure undefined[m
+       Retries: 3 (does not look flaky)
+       Prelude.undefined
+       CallStack (from HasCallStack):
+         undefined, called at output-test/Spec.hs:39:28 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
+  
+  [36m  output-test/Spec.hs:40[m
+  [31m✗ [m[31m5 [m[31mExit code[m
+       Retries: 3 (does not look flaky)
+       ExitFailure 1
+  
+  [36m  output-test/Spec.hs:48[m
+  [31m✗ [m[31m6 [m[31mexceptions.Record construction error[m
+       Retries: 3 (does not look flaky)
+       test
+  
+  [36m  output-test/Spec.hs:45[m
+  [31m✗ [m[31m7 [m[31mexceptions.Record construction error.fails in IO, as the result[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:49:57-64: Missing field in record construction field
+  
+  [36m  output-test/Spec.hs:46[m
+  [31m✗ [m[31m8 [m[31mexceptions.Record construction error.fails in IO, as the action[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:49:57-64: Missing field in record construction field
+  
+  [36m  output-test/Spec.hs:47[m
+  [31m✗ [m[31m9 [m[31mexceptions.Record construction error.fails in pure code[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:49:57-64: Missing field in record construction field
+  
+  [36m  output-test/Spec.hs:50[m
+  [31m✗ [m[31m10 [m[31mexceptions.Record selection error[m
+       Retries: 3 (does not look flaky)
+       test
+  
+  [36m  output-test/Spec.hs:45[m
+  [31m✗ [m[31m11 [m[31mexceptions.Record selection error.fails in IO, as the result[m
+       Retries: 3 (does not look flaky)
+       No match in record selector field
+  
+  [36m  output-test/Spec.hs:46[m
+  [31m✗ [m[31m12 [m[31mexceptions.Record selection error.fails in IO, as the action[m
+       Retries: 3 (does not look flaky)
+       No match in record selector field
+  
+  [36m  output-test/Spec.hs:47[m
+  [31m✗ [m[31m13 [m[31mexceptions.Record selection error.fails in pure code[m
+       Retries: 3 (does not look flaky)
+       No match in record selector field
+  
+  [36m  output-test/Spec.hs:52[m
+  [31m✗ [m[31m14 [m[31mexceptions.Record update error[m
+       Retries: 3 (does not look flaky)
+       test
+  
+  [36m  output-test/Spec.hs:45[m
+  [31m✗ [m[31m15 [m[31mexceptions.Record update error.fails in IO, as the result[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:53:60-88: Non-exhaustive patterns in case
+  
+  [36m  output-test/Spec.hs:46[m
+  [31m✗ [m[31m16 [m[31mexceptions.Record update error.fails in IO, as the action[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:53:60-88: Non-exhaustive patterns in case
+  
+  [36m  output-test/Spec.hs:47[m
+  [31m✗ [m[31m17 [m[31mexceptions.Record update error.fails in pure code[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:53:60-88: Non-exhaustive patterns in case
+  
+  [36m  output-test/Spec.hs:54[m
+  [31m✗ [m[31m18 [m[31mexceptions.Pattern matching error[m
+       Retries: 3 (does not look flaky)
+       test
+  
+  [36m  output-test/Spec.hs:45[m
+  [31m✗ [m[31m19 [m[31mexceptions.Pattern matching error.fails in IO, as the result[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:55:50-64: Non-exhaustive patterns in Cons1 s
+  
+  [36m  output-test/Spec.hs:46[m
+  [31m✗ [m[31m20 [m[31mexceptions.Pattern matching error.fails in IO, as the action[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:55:50-64: Non-exhaustive patterns in Cons1 s
+  
+  [36m  output-test/Spec.hs:47[m
+  [31m✗ [m[31m21 [m[31mexceptions.Pattern matching error.fails in pure code[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:55:50-64: Non-exhaustive patterns in Cons1 s
+  
+  [36m  output-test/Spec.hs:56[m
+  [31m✗ [m[31m22 [m[31mexceptions.ArithException[m
+       Retries: 3 (does not look flaky)
+       arithmetic underflow
+  
+  [36m  output-test/Spec.hs:45[m
+  [31m✗ [m[31m23 [m[31mexceptions.Pattern matching error.fails in IO, as the result[m
+       Retries: 3 (does not look flaky)
+       divide by zero
+  
+  [36m  output-test/Spec.hs:46[m
+  [31m✗ [m[31m24 [m[31mexceptions.Pattern matching error.fails in IO, as the action[m
+       Retries: 3 (does not look flaky)
+       divide by zero
+  
+  [36m  output-test/Spec.hs:47[m
+  [31m✗ [m[31m25 [m[31mexceptions.Pattern matching error.fails in pure code[m
+       Retries: 3 (does not look flaky)
+       divide by zero
+  
+  [36m  output-test/Spec.hs:58[m
+  [31m✗ [m[31m26 [m[31mexceptions.NoMethodError[m
+       Retries: 3 (does not look flaky)
+       test
+  
+  [36m  output-test/Spec.hs:45[m
+  [31m✗ [m[31m27 [m[31mexceptions.Pattern matching error.fails in IO, as the result[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:29:10-19: No instance nor default method for class operation toUnit
+  
+  [36m  output-test/Spec.hs:46[m
+  [31m✗ [m[31m28 [m[31mexceptions.Pattern matching error.fails in IO, as the action[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:29:10-19: No instance nor default method for class operation toUnit
+  
+  [36m  output-test/Spec.hs:47[m
+  [31m✗ [m[31m29 [m[31mexceptions.Pattern matching error.fails in pure code[m
+       Retries: 3 (does not look flaky)
+       output-test/Spec.hs:29:10-19: No instance nor default method for class operation toUnit
+  
+  [36m  output-test/Spec.hs:72[m
+  [31m✗ [m[31m30 [m[31mProperty tests.pure.should fail to show that sorting does nothing[m
+       Retries: 3 (does not look flaky)
+       Failed after 3 tests
+       Generated: [33m[-5,3,11,-3,-13,0,19,-10,15,-13,1,-12,10,-18,-3,-2,6,-9,-6][m
+  
+  [36m  output-test/Spec.hs:80[m
+  [31m✗ [m[31m31 [m[31mProperty tests.impure.should fail to show that sorting does nothing[m
+       Retries: 3 (does not look flaky)
+       Failed after 3 tests
+       Generated: [33m[-5,3,11,-3,-13,0,19,-10,15,-13,1,-12,10,-18,-3,-2,6,-9,-6][m
+       Expected these values to be equal:
+       [34mActual:   [m
+       [ -[31m1[m[31m8[m
+       , [31m-[m1[31m3[m
+       , -[31m1[m3
+       , -1[31m2[m
+       , [31m-1[m0
+       , [31m-[m9
+       , -[31m6[m
+       , [31m-[m5
+       , -3
+       , [31m-[m[31m3[m
+       , -2
+       , 0
+       , 1
+       , 3
+       , [31m6[m
+       , [31m1[m[31m0[m
+       , [31m11[m
+       [31m, 1[m[31m5[m
+       , [31m1[m[31m9[m
+       ]
+       [34mExpected: [m
+       [ -[32m5[m[42m[m
+       [42m[m[32m, [m[32m3[m
+       , 1[32m1[m
+       , -3
+       , -1[32m3[m
+       , 0
+       , [32m1[m9
+       , -[32m1[m[32m0[m
+       , [32m1[m5
+       , -[32m1[m3
+       , [32m1[m
+       , -[32m1[m2
+       , [32m1[m0
+       , [32m-[m1[32m8[m
+       , [32m-[m3
+       , [32m-[m[32m2[m
+       , [32m6[m
+       , [32m-[m[32m9[m
+       , [32m-6[m
+       ]
+       [34mInline diff: [m
+       [ -[32m5[m[42m[m
+       [42m[m[32m, [m[31m1[m[32m3[m[31m8[m
+       , [31m-[m1[32m1[m[31m3[m
+       , -[31m1[m3
+       , -1[32m3[m[31m2[m
+       , [31m-1[m0
+       , [31m-[m[32m1[m9
+       , -[32m1[m[31m6[m[32m0[m
+       , [32m1[m[31m-[m5
+       , -[32m1[m3
+       , [31m-[m[31m3[m[32m1[m
+       , -[32m1[m2
+       , [32m1[m0
+       , [32m-[m1[32m8[m
+       , [32m-[m3
+       , [32m-[m[31m6[m[32m2[m
+       , [31m1[m[31m0[m[32m6[m
+       , [32m-[m[31m11[m
+       [31m, 1[m[31m5[m[32m9[m
+       , [31m1[m[32m-6[m[31m9[m
+       ]
+  
+  [36m  output-test/Spec.hs:90[m
+  [31m✗ [m[31m32 [m[31mDiff.shows nice multi-line diffs[m
+       Retries: 3 (does not look flaky)
+       Expected these values to be equal:
+       [34mActual:   [m
+       ( "foo"
+       , [[41m [m[31m"qu[m[31mux[m[31m"[m [31m,[m[41m [m"quux" , "quux" , "quux" , "quux" , "quux" , "quux" ]
+       , "ba[31mr[m"
+       )
+       [34mExpected: [m
+       ( "[32mf[m[32mo[m[32mo[mfoo"
+       , [ "quux" , "quux" , "quux" , "quux" , "quux" , "quux" ]
+       , "ba[32mz[m"
+       )
+       [34mInline diff: [m
+       ( "[32mf[m[32mo[m[32mo[mfoo"
+       , [[41m [m[31m"qu[m[31mux[m[31m"[m [31m,[m[41m [m"quux" , "quux" , "quux" , "quux" , "quux" , "quux" ]
+       , "ba[32mz[m[31mr[m"
+       )
+  
+  [36m  output-test/Spec.hs:92[m
+  [31m✗ [m[31m33 [m[31mDiff.shows nice multi-line diffs[m
+       Retries: 3 (does not look flaky)
+       Expected these values to be equal:
+       [34mActual:   [m( "foo"[41m [m, [[31m][m , "ba[31mr[m"[41m [m)
+       [34mExpected: [m
+       ( "[32mf[m[32mo[m[32mo[mfoo"[42m[m
+       [42m[m, [[32m "[m[32mquux" , [m[32m"quux" , "quux" [m[32m, "quux" , "quux[m[32m" , "quu[m[32mx"[m [32m][m
+       [32m[m, "ba[32mz[m"[42m[m
+       [42m[m)
+       [34mInline diff: [m
+       ( "[32mf[m[32mo[m[32mo[mfoo"[41m [m[42m[m
+       [42m[m, [[31m][m[32m "[m[32mquux" , [m[32m"quux" , "quux" [m[32m, "quux" , "quux[m[32m" , "quu[m[32mx"[m [32m][m
+       [32m[m, "ba[31mr[m[32mz[m"[41m [m[42m[m
+       [42m[m)
+  
+  [36m  output-test/Spec.hs:95[m
+  [31m✗ [m[31m34 [m[31massertions.shouldBe[m
+       Retries: 3 (does not look flaky)
+       Expected these values to be equal:
+       [34mActual:   [m[31m3[m
+       [34mExpected: [m[32m4[m
+  
+  [36m  output-test/Spec.hs:96[m
+  [31m✗ [m[31m35 [m[31massertions.shouldNotBe[m
+       Retries: 3 (does not look flaky)
+       Did not expect equality of the values but both were:
+       3
+  
+  [36m  output-test/Spec.hs:97[m
+  [31m✗ [m[31m36 [m[31massertions.shouldSatisfy[m
+       Retries: 3 (does not look flaky)
+       Predicate failed, but should have succeeded, on this value:
+       3
+  
+  [36m  output-test/Spec.hs:98[m
+  [31m✗ [m[31m37 [m[31massertions.shouldNotSatisfy[m
+       Retries: 3 (does not look flaky)
+       Predicate succeeded, but should have failed, on this value:
+       3
+  
+  [36m  output-test/Spec.hs:99[m
+  [31m✗ [m[31m38 [m[31massertions.shouldSatisfyNamed[m
+       Retries: 3 (does not look flaky)
+       Predicate failed, but should have succeeded, on this value:
+       3
+       Predicate: even
+  
+  [36m  output-test/Spec.hs:100[m
+  [31m✗ [m[31m39 [m[31massertions.shouldNotSatisfyNamed[m
+       Retries: 3 (does not look flaky)
+       Predicate succeeded, but should have failed, on this value:
+       3
+       Predicate: odd
+  
+  [36m  output-test/Spec.hs:103[m
+  [31m✗ [m[31m40 [m[31mGolden.does not fail the suite when an exception happens while reading[m
+       Retries: 3 (does not look flaky)
+       ExitFailure 1
+  
+  [36m  output-test/Spec.hs:111[m
+  [31m✗ [m[31m41 [m[31mGolden.does not fail the suite when an exception happens while producing[m
+       Retries: 3 (does not look flaky)
+       ExitFailure 1
+  
+  [36m  output-test/Spec.hs:119[m
+  [31m✗ [m[31m42 [m[31mGolden.does not fail the suite when an exception happens while writing[m
+       Retries: 3 (does not look flaky)
+       ExitFailure 1
+  
+  [36m  output-test/Spec.hs:126[m
+  [31m✗ [m[31m43 [m[31mGolden.does not fail the suite when an exception happens while checking for equality[m
+       Retries: 3 (does not look flaky)
+       divide by zero
+  
+  [36m  output-test/Spec.hs:149[m
+  [31m✗ [m[31m44 [m[31mAround.before.does not kill the test suite[m
+       Retries: 3 (does not look flaky)
+       user error (test)
+  
+  [36m  output-test/Spec.hs:154[m
+  [31m✗ [m[31m45 [m[31mAround.before_.does not kill the test suite[m
+       Retries: 3 (does not look flaky)
+       user error (test)
+  
+  [36m  output-test/Spec.hs:159[m
+  [31m✗ [m[31m46 [m[31mAround.after.does not kill the test suite[m
+       Retries: 3 (does not look flaky)
+       user error (test)
+  
+  [36m  output-test/Spec.hs:164[m
+  [31m✗ [m[31m47 [m[31mAround.after_.does not kill the test suite[m
+       Retries: 3 (does not look flaky)
+       user error (test)
+  
+  [36m  output-test/Spec.hs:169[m
+  [31m✗ [m[31m48 [m[31mAround.around.does not kill the test suite[m
+       Retries: 3 (does not look flaky)
+       user error (test)
+  
+  [36m  output-test/Spec.hs:174[m
+  [31m✗ [m[31m49 [m[31mAround.around_.does not kill the test suite[m
+       Retries: 3 (does not look flaky)
+       user error (test)
+  
+  [36m  output-test/Spec.hs:179[m
+  [31m✗ [m[31m50 [m[31mAround.aroundWith.does not kill the test suite[m
+       Retries: 3 (does not look flaky)
+       user error (test)
+  
+  [36m  output-test/Spec.hs:184[m
+  [31m✗ [m[31m51 [m[31mAround.aroundWith'.does not kill the test suite[m
+       Retries: 3 (does not look flaky)
+       user error (test)
+  
+  [36m  output-test/Spec.hs:187[m
+  [31m✗ [m[31m52 [m[31mexpectationFailure[m
+       Retries: 3 (does not look flaky)
+       fails
+  
+  [36m  output-test/Spec.hs:190[m
+  [31m✗ [m[31m53 [m[31mString.compares strings[m
+       Retries: 3 (does not look flaky)
+       Expected these values to be equal:
+       [34mActual:   [m"f[31mo[mo\nba[31mr[m\tq[31muu[mx[41m [m"
+       [34mExpected: [m"fo[32mq[m\nba[32mz[m\tq[32me[mx"
+  
+  [36m  output-test/Spec.hs:191[m
+  [31m✗ [m[31m54 [m[31mString.compares strings[m
+       Retries: 3 (does not look flaky)
+       Expected these values to be equal:
+       [34mActual:   [m"f[31mo[mo\nba[31mr[m\tq[31muu[mx[41m [m"
+       [34mExpected: [m"fo[32mq[m\nba[32mz[m\tq[32me[mx"
+  
+  [36m  output-test/Spec.hs:192[m
+  [31m✗ [m[31m55 [m[31mString.compares texts[m
+       Retries: 3 (does not look flaky)
+       Expected these values to be equal:
+       [34mActual:   [m"f[31mo[mo\nba[31mr[m\tq[31muu[mx[41m [m"
+       [34mExpected: [m"fo[32mq[m\nba[32mz[m\tq[32me[mx"
+  
+  [36m  output-test/Spec.hs:193[m
+  [31m✗ [m[31m56 [m[31mString.compares texts[m
+       Retries: 3 (does not look flaky)
+       Expected these values to be equal:
+       [34mActual:   [m"f[31mo[mo\nba[31mr[m\tq[31muu[mx[41m [m"
+       [34mExpected: [m"fo[32mq[m\nba[32mz[m\tq[32me[mx"
+  
+  [36m  output-test/Spec.hs:194[m
+  [31m✗ [m[31m57 [m[31mString.compares bytestrings[m
+       Retries: 3 (does not look flaky)
+       Expected these values to be equal:
+       [34mActual:   [m"f[31mo[mo\nba[31mr[m\tq[31muu[mx[41m [m"
+       [34mExpected: [m"fo[32mq[m\nba[32mz[m\tq[32me[mx"
+  
+  [36m  output-test/Spec.hs:197[m
+  [31m✗ [m[31m58 [m[31mContext.shows a nice context[m
+       Retries: 3 (does not look flaky)
+       Expected these values to be equal:
+       [34mActual:   [m[31mTr[m[31mu[me
+       [34mExpected: [m[32mFals[me
+       Context
+  
+  [36m  output-test/Spec.hs:198[m
+  [31m✗ [m[31m59 [m[31mContext.shows a nice context multiple levels deep[m
+       Retries: 3 (does not look flaky)
+       Expected these values to be equal:
+       [34mActual:   [m[31mTr[m[31mu[me
+       [34mExpected: [m[32mFals[me
+       Context3
+       Context2
+       Context1
+  
+  [36m  output-test/Spec.hs:203[m
+  [31m✗ [m[31m60 [m[31mContext.shows a context when an exception is thrown as well[m
+       Retries: 3 (does not look flaky)
+       Prelude.undefined
+       CallStack (from HasCallStack):
+         undefined, called at output-test/Spec.hs:204:26 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
+       context
+  
+  [36m  output-test/Spec.hs:210[m
+  [31m✗ [m[31m61 [m[31mProperty.generated values.shows many generated values too[m
+       Retries: 3 (does not look flaky)
+       Failed after 1 tests
+       Generated: [33m0[m
+       Generated: [33m0[m
+       Generated: [33m0[m
+       Generated: [33m0[m
+       Generated: [33m0[m
+       Expected these values to be equal:
+       [34mActual:   [m[31m0[m
+       [34mExpected: [m[32m1[m
+  
+  [36m  output-test/Spec.hs:229[m
+  [31m✗ [m[31m62 [m[31mProperty.labels.shows the labels in use on failure[m
+       Retries: 3 (does not look flaky)
+       Failed after 1 tests
+       Generated: [33m[][m
+       Labels: "length of input is 0", "magnitude (digits) of sum of input is 0"
+       Expected these values to be equal:
+       [34mActual:   [m[]
+       [34mExpected: [m[[42m [m[32m0[m[42m [m]
+  
+  [36m  output-test/Spec.hs:246[m
+  [31m✗ [m[31m63 [m[31mProperty.classes.shows the classes in use on failure[m
+       Retries: 3 (does not look flaky)
+       Failed after 1 tests
+       Generated: [33m[][m
+       Class: empty
+       Expected these values to be equal:
+       [34mActual:   [m[]
+       [34mExpected: [m[[42m [m[32m0[m[42m [m]
+  
+  [36m  output-test/Spec.hs:269[m
+  [31m✗ [m[31m64 [m[31mShrinking.can grab the mvar during shrinking[m
+       Retries: 3 (does not look flaky)
+       Failed after 21 tests
+       Generated: [33m20[m
+       Predicate failed, but should have succeeded, on this value:
+       20
+  
+  [36m  output-test/Spec.hs:276[m
+  [31m✗ [m[31m65 [m[31mRetries.does not retry if the test is configured withoutRetries[m
+  
+  [36m  output-test/Spec.hs:278[m
+  [31m✗ [m[31m66 [m[31mRetries.Retries this five times[m
+       Retries: 5 (does not look flaky)
+  
+  [36m  output-test/Spec.hs:283[m
+  [31m✗ [m[31m67 [m[31mFlakiness.Allows flakiness on False eventhough there is none (should fail)[m
+       Retries: 3 (does not look flaky)
+  
+  [36m  output-test/Spec.hs:292[m
+  [31m✗ [m[31m68 [m[31mFlakiness.Does not allow flakiness if flakiness is not allowed even if retries happen[m
+       Retries: 2[31m !!! FLAKY !!![m
+       Expected these values to be equal:
+       [34mActual:   [m[31m1[m
+       [34mExpected: [m[32m2[m
+  
+  [36m  output-test/Spec.hs:296[m
+  [31m✗ [m[31m69 [m[31mFlakiness.Allows flakiness in this boolean five times (should fail with 5 retries)[m
+       Retries: 5 (does not look flaky)
+  
+  [36m  output-test/Spec.hs:316[m
+  [31m✗ [m[31m70 [m[31mcallstack.it[m
+       Retries: 3 (does not look flaky)
+  
+  [36m  output-test/Spec.hs:317[m
+  [31m✗ [m[31m71 [m[31mcallstack.specify[m
+       Retries: 3 (does not look flaky)
+  
+  [36m  Unknown location[m
+  [31m✗ [m[31m72 [m[31mcallstack.prop[m
+       Retries: 3 (does not look flaky)
+       Failed after 1 tests
+  
+  [36m  output-test/Spec.hs:320[m
+  [31m✗ [m[31m73 [m[31mcallstack.describe.describe-it[m
+       Retries: 3 (does not look flaky)
+  
+  [36m  output-test/Spec.hs:321[m
+  [31m✗ [m[31m74 [m[31mcallstack.describe.describe-specify[m
+       Retries: 3 (does not look flaky)
+  
+  [36m  output-test/Spec.hs:328[m
+  [31m✗ [m[31m75 [m[31mexpectations.considered failing[m
+       Retries: 3 (does not look flaky)
+  
+  [36m  output-test/Spec.hs:329[m
+  [31m✗ [m[31m76 [m[31mexpectations.considered failing[m
+       Retries: 3 (does not look flaky)
+  
+  [36m  output-test/Spec.hs:336[m
+  [31m✗ [m[31m77 [m[31mcombinators.should fail[m
+       Retries: 3 (does not look flaky)
+       Failed after 2 tests
+       Generated: [33m-1[m
+  
+  [36m  output-test/Spec.hs:338[m
+  [31m✗ [m[31m78 [m[31mcombinators.should not crash (undefined value)[m
+       Retries: 3 (does not look flaky)
+       Failed after 1 tests
+       Generated: [33m0[m
+       Prelude.undefined
+       CallStack (from HasCallStack):
+         undefined, called at output-test/Spec.hs:338:80 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
+  
+  [36m  output-test/Spec.hs:339[m
+  [31m✗ [m[31m79 [m[31mcombinators.should not crash (undefined generator)[m
+       Retries: 3 (does not look flaky)
+       Failed after 1 tests
+       Generated: [33mException thrown while showing test case:
+  Prelude.undefined
+  CallStack (from HasCallStack):
+    undefined, called at output-test/Spec.hs:339:74 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
+[m
+       Prelude.undefined
+       CallStack (from HasCallStack):
+         undefined, called at output-test/Spec.hs:339:74 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
+  
+  [36m  output-test/Spec.hs:342[m
+  [31m✗ [m[31m80 [m[31mcombinators.should be even[m
+       Retries: 3 (does not look flaky)
+  
+  [36m  output-test/Spec.hs:342[m
+  [31m✗ [m[31m81 [m[31mcombinators.should be even[m
+       Retries: 3 (does not look flaky)
+       Prelude.undefined
+       CallStack (from HasCallStack):
+         undefined, called at output-test/Spec.hs:345:29 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
+  
+  [36m  output-test/Spec.hs:348[m
+  [31m✗ [m[31m82 [m[31mrandomness.always outputs the same pseudorandomness[m
+       Retries: 3 (does not look flaky)
+       Expected these values to be equal:
+       [34mActual:   [m[31m4[m[31m9[m
+       [34mExpected: [m[32m2[m
+  
+
+  Examples:                     [32m984[m
+  Passed:                       [32m31[m
+  Failed:                       [31m82[m
+  Flaky:                        [31m3[m
+  Pending:                      [35m7[m
+  Sum of test runtimes:[33m         0.00 seconds[m
+  Test suite took:     [33m         0.00 seconds[m
+

--- a/test_resources/output.golden
+++ b/test_resources/output.golden
@@ -1,0 +1,10 @@
+[34mTests:[m
+
+
+
+
+  Passed:                       [32m0[m
+  Failed:                       [32m0[m
+  Sum of test runtimes:[33m         0.00 seconds[m
+  Test suite took:     [33m         0.00 seconds[m
+


### PR DESCRIPTION
But this partially fix https://github.com/NorfairKing/sydtest/issues/92 by introducing a timeout of 2s on the diff computatation.

The 2s is hardcoded yada yada


Don't merge, I will detail the commit message later and discuss the `unsafePerformIO` trick (if you accept it ;)