### PR TITLE
Safer withargs

### DIFF
--- a/sydtest/src/Test/Syd/Runner.hs
+++ b/sydtest/src/Test/Syd/Runner.hs
@@ -30,6 +30,14 @@ import Test.Syd.SpecDef
 import Text.Colour
 import Text.Printf
 
+-- | Set the command line argument of the underlying action to empty.
+--
+-- The action behaves as if no command line argument were provided. Especially,
+-- it removes all the arguments initially provided to sydtest and provides a
+-- reproducible environment.
+setNullArgs :: IO a -> IO a
+setNullArgs action = withArgs [] action
+
 sydTestResult :: Settings -> TestDefM '[] () r -> IO (Timed ResultForest)
 sydTestResult settings spec = do
   let totalIterations = case settingIterations settings of
@@ -44,7 +52,7 @@ sydTestOnce :: Settings -> TestDefM '[] () r -> IO (Timed ResultForest)
 sydTestOnce settings spec = do
   specForest <- execTestDefM settings spec
   tc <- deriveTerminalCapababilities settings
-  withArgs [] $ do
+  setNullArgs $ do
     setPseudorandomness (settingSeed settings)
     case settingThreads settings of
       Synchronous -> runSpecForestInterleavedWithOutputSynchronously settings specForest
@@ -71,7 +79,7 @@ sydTestOnce settings spec = do
 
 sydTestIterations :: Maybe Word -> Settings -> TestDefM '[] () r -> IO (Timed ResultForest)
 sydTestIterations totalIterations settings spec =
-  withArgs [] $ do
+  setNullArgs $ do
     nbCapabilities <- fromIntegral <$> getNumCapabilities
 
     let runOnce settings_ = do


### PR DESCRIPTION
This closes https://github.com/NorfairKing/sydtest/issues/91 by avoiding
a call to `withArgs` if the argument list is already empty.

`withArgs` can crash in a concurrent environment (see GHC BUG
https://gitlab.haskell.org/ghc/ghc/-/issues/18261), hence we reduce the
chance of this happening by not calling it when the list of arguments is
already in the required state (e.g. empty).