### PR TITLE
fix: text and string assertion error correctly outputs multi-line strings

### DIFF
--- a/sydtest-test/test_resources/output-test.txt
+++ b/sydtest-test/test_resources/output-test.txt
@@ -710,8 +710,15 @@
   [31m✗ [m[31m54 [m[31mString.compares strings[m
        Retries: 3 (does not look flaky)
        Expected these values to be equal:
-       [34mActual:   [m"f[31mo[mo\nba[31mr[m\tq[31muu[mx[41m [m"
-       [34mExpected: [m"fo[32mq[m\nba[32mz[m\tq[32me[mx"
+       [34mActual:   [m
+       f[31mo[mo
+       ba[31mr[m	q[31muu[mx[41m [m
+       [34mExpected: [m
+       fo[32mq[m
+       ba[32mz[m	q[32me[mx
+       [34mInline diff: [m
+       f[31mo[mo[32mq[m
+       ba[31mr[m[32mz[m	q[31muu[m[32me[mx[41m [m
   
   [36m  output-test/Spec.hs:192[m
   [31m✗ [m[31m55 [m[31mString.compares texts[m
@@ -724,8 +731,15 @@
   [31m✗ [m[31m56 [m[31mString.compares texts[m
        Retries: 3 (does not look flaky)
        Expected these values to be equal:
-       [34mActual:   [m"f[31mo[mo\nba[31mr[m\tq[31muu[mx[41m [m"
-       [34mExpected: [m"fo[32mq[m\nba[32mz[m\tq[32me[mx"
+       [34mActual:   [m
+       f[31mo[mo
+       ba[31mr[m	q[31muu[mx[41m [m
+       [34mExpected: [m
+       fo[32mq[m
+       ba[32mz[m	q[32me[mx
+       [34mInline diff: [m
+       f[31mo[mo[32mq[m
+       ba[31mr[m[32mz[m	q[31muu[m[32me[mx[41m [m
   
   [36m  output-test/Spec.hs:194[m
   [31m✗ [m[31m57 [m[31mString.compares bytestrings[m

--- a/sydtest/CHANGELOG.md
+++ b/sydtest/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.18.0.1] - 2024-11-01
+
+### Changed
+
+- Fixed `mkNotEqualButShouldHaveBeenEqual` logic so it keeps the escape
+  sequence for `Text` and `String`. This fix a regression introduced in
+  0.18.0.0.
+
 ## [0.18.0.0] - 2024-09-26
 
 ### Added

--- a/sydtest/default.nix
+++ b/sydtest/default.nix
@@ -6,7 +6,7 @@
 }:
 mkDerivation {
   pname = "sydtest";
-  version = "0.18.0.0";
+  version = "0.18.0.1";
   src = ./.;
   libraryHaskellDepends = [
     async autodocodec base bytestring containers deepseq dlist

--- a/sydtest/package.yaml
+++ b/sydtest/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest
-version: 0.18.0.0
+version: 0.18.0.1
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest/src/Test/Syd/Expectation.hs
+++ b/sydtest/src/Test/Syd/Expectation.hs
@@ -29,7 +29,7 @@ import Text.Show.Pretty
 
 -- | Assert that two values are equal according to `==`.
 shouldBe :: (HasCallStack, Show a, Eq a) => a -> a -> IO ()
-shouldBe actual expected = unless (actual == expected) $ throwIO =<< mkNotEqualButShouldHaveBeenEqual actual expected
+shouldBe actual expected = unless (actual == expected) $ throwIO =<< mkNotEqualButShouldHaveBeenEqual (ppShow actual) (ppShow expected)
 
 infix 1 `shouldBe`
 
@@ -63,7 +63,7 @@ shouldNotSatisfyNamed actual name p = when (p actual) $ throwIO $ PredicateSucce
 shouldReturn :: (HasCallStack, Show a, Eq a) => IO a -> a -> IO ()
 shouldReturn computeActual expected = do
   actual <- computeActual
-  unless (actual == expected) $ throwIO =<< mkNotEqualButShouldHaveBeenEqual actual expected
+  unless (actual == expected) $ throwIO =<< mkNotEqualButShouldHaveBeenEqual (ppShow actual) (ppShow expected)
 
 infix 1 `shouldReturn`
 

--- a/sydtest/src/Test/Syd/Run.hs
+++ b/sydtest/src/Test/Syd/Run.hs
@@ -40,7 +40,6 @@ import Test.QuickCheck.Property hiding (Result (..))
 import qualified Test.QuickCheck.Property as QCP
 import Test.QuickCheck.Random
 import Text.Printf
-import Text.Show.Pretty (ppShow)
 
 class IsTest e where
   -- | The argument from 'aroundAll'
@@ -519,22 +518,18 @@ computeDiff a b = V.toList $ getTextDiff (T.pack a) (T.pack b)
 -- | Assertion when both arguments are not equal. While display a diff between
 -- both at the end of tests. The diff computation is cancelled after 2s.
 mkNotEqualButShouldHaveBeenEqual ::
-  (Show a) =>
-  a ->
-  a ->
+  String ->
+  String ->
   IO Assertion
 mkNotEqualButShouldHaveBeenEqual actual expected = do
-  let ppActual = ppShow actual
-  let ppExpected = ppShow expected
-
-  let diffNotEvaluated = computeDiff ppActual ppExpected
+  let diffNotEvaluated = computeDiff actual expected
   -- we want to evaluate the diff in order to ensure that its
   -- computation happen in the timeout block
   -- and is not instead later because of lazy evaluation.
   --
   -- The safe option here is to evaluate to normal form with `force`.
   diff <- timeout 2e6 (evaluate (force diffNotEvaluated))
-  pure $ NotEqualButShouldHaveBeenEqualWithDiff ppActual ppExpected diff
+  pure $ NotEqualButShouldHaveBeenEqualWithDiff actual expected diff
 
 instance Exception Assertion
 

--- a/sydtest/sydtest.cabal
+++ b/sydtest/sydtest.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest
-version:        0.18.0.0
+version:        0.18.0.1
 synopsis:       A modern testing framework for Haskell with good defaults and advanced testing features.
 description:    A modern testing framework for Haskell with good defaults and advanced testing features. Sydtest aims to make the common easy and the hard possible. See https://github.com/NorfairKing/sydtest#readme for more information.
 category:       Testing


### PR DESCRIPTION
This fix a regression introduced in
e8a16c3d8efab097e9c1f07b828d690af8930d3d when formatting `Text` and `String`: `ppShow` was always used, leading to escape sequences (mostly `\n` to be displayed as literal (e.g. `\n`) instead of the associated character (e.g. a line break) leading to poor diff display because everything is displayed on a unique line.

Instead of applying `ppShow` on all input of
`mkNotEqualButShouldHaveBeenEqual`, leading to `Text` and `String` using their `Show` instances, we only apply `ppShow` on the function which are formatting any object (using their `Show` instance), or `ByteString`. For `String` and `Text`, it uses the natural display logic of them.

@NorfairKing I'm really sorry about this mistake. I've setup the MR to introduce a patch version bump release.