### PR TITLE
Fix sydtest-hspec failure output

### DIFF
--- a/sydtest-hspec/CHANGELOG.md
+++ b/sydtest-hspec/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.0.4] - 2025-01-07
+
+### Changed
+
+ * Fixed test failure report when using `mkNotEqualButShouldHaveBeenEqual`
+
 ## [0.4.0.3] - 2024-10-13
 
 ### Added

--- a/sydtest-hspec/default.nix
+++ b/sydtest-hspec/default.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "sydtest-hspec";
-  version = "0.4.0.3";
+  version = "0.4.0.4";
   src = ./.;
   libraryHaskellDepends = [
     base hspec-core mtl QuickCheck stm sydtest

--- a/sydtest-hspec/default.nix
+++ b/sydtest-hspec/default.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, base, hspec, hspec-core, lib, mtl, QuickCheck, stm
-, sydtest, sydtest-discover
+{ mkDerivation, base, hspec, hspec-core, lib, mtl, QuickCheck
+, safe-coloured-text, stm, sydtest, sydtest-discover, text
 }:
 mkDerivation {
   pname = "sydtest-hspec";
@@ -8,7 +8,9 @@ mkDerivation {
   libraryHaskellDepends = [
     base hspec-core mtl QuickCheck stm sydtest
   ];
-  testHaskellDepends = [ base hspec stm sydtest ];
+  testHaskellDepends = [
+    base hspec safe-coloured-text stm sydtest text
+  ];
   testToolDepends = [ sydtest-discover ];
   homepage = "https://github.com/NorfairKing/sydtest#readme";
   description = "An Hspec companion library for sydtest";

--- a/sydtest-hspec/package.yaml
+++ b/sydtest-hspec/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest-hspec
-version: 0.4.0.3
+version: 0.4.0.4
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest-hspec/package.yaml
+++ b/sydtest-hspec/package.yaml
@@ -36,6 +36,8 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - hspec
+    - safe-coloured-text
     - stm
     - sydtest
     - sydtest-hspec
+    - text

--- a/sydtest-hspec/sydtest-hspec.cabal
+++ b/sydtest-hspec/sydtest-hspec.cabal
@@ -46,6 +46,7 @@ test-suite sydtest-hspec-test
   other-modules:
       Spec
       Test.Syd.HspecSpec
+      Test.Syd.OutputSpec
       Paths_sydtest_hspec
   hs-source-dirs:
       test
@@ -55,7 +56,9 @@ test-suite sydtest-hspec-test
   build-depends:
       base >=4.7 && <5
     , hspec
+    , safe-coloured-text
     , stm
     , sydtest
     , sydtest-hspec
+    , text
   default-language: Haskell2010

--- a/sydtest-hspec/sydtest-hspec.cabal
+++ b/sydtest-hspec/sydtest-hspec.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest-hspec
-version:        0.4.0.3
+version:        0.4.0.4
 synopsis:       An Hspec companion library for sydtest
 category:       Testing
 homepage:       https://github.com/NorfairKing/sydtest#readme

--- a/sydtest-hspec/test/Test/Syd/OutputSpec.hs
+++ b/sydtest-hspec/test/Test/Syd/OutputSpec.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Syd.OutputSpec (spec) where
+
+import Control.Exception (AssertionFailed (..), throwIO)
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Builder as TLB
+import Test.Hspec
+import qualified Test.Syd as Syd
+import Test.Syd.Hspec (fromHspec)
+import Test.Syd.OptParse (getSettings)
+import Text.Colour
+
+spec :: Syd.Spec
+spec =
+  Syd.describe "Golden Output" $
+    Syd.it "renders output in the same way as before" $
+      Syd.goldenTextFile "test_resources/output-test.txt" $ do
+        settings <- getSettings
+        testForest <- Syd.execTestDefM settings (fromHspec hspecSpec)
+        res <- Syd.timeItT 0 $ Syd.runSpecForestSynchronously settings testForest
+
+        pure
+          $ LT.toStrict
+            . TLB.toLazyText
+            . Syd.renderResultReport settings WithoutColours
+          $ eraseTiming res
+
+hspecSpec :: Spec
+hspecSpec = do
+  it "failure with no reason" False
+
+  it "failure with reason" $ expectationFailure "failure reason"
+
+  it "failure with \"expected x but got y\"" $ 8 `shouldBe` (6 :: Int)
+
+  it "failure with error" $ do
+    throwIO (AssertionFailed "error msg") :: IO ()
+
+eraseTiming :: Syd.Timed Syd.ResultForest -> Syd.Timed Syd.ResultForest
+eraseTiming = fmap erasedTimedInResultForest . eraseTimed
+  where
+    eraseTimed :: Syd.Timed a -> Syd.Timed a
+    eraseTimed t =
+      t
+        { Syd.timedBegin = 0,
+          Syd.timedEnd = 0,
+          Syd.timedWorker = 0
+        }
+
+    erasedTimedInResultForest :: Syd.ResultForest -> Syd.ResultForest
+    erasedTimedInResultForest = fmap (fmap (fmap eraseTimed))

--- a/sydtest-hspec/test_resources/output-test.txt
+++ b/sydtest-hspec/test_resources/output-test.txt
@@ -1,0 +1,43 @@
+Tests:
+
+✗ failure with no reason                                                   0.00 ms
+  Retries: 3 (does not look flaky)
+✗ failure with reason                                                      0.00 ms
+  Retries: 3 (does not look flaky)
+✗ failure with "expected x but got y"                                      0.00 ms
+  Retries: 3 (does not look flaky)
+✗ failure with error                                                       0.00 ms
+  Retries: 3 (does not look flaky)
+
+
+Failures:
+
+    src/Test/Syd/Hspec.hs:68
+  ✗ 1 failure with no reason
+      Retries: 3 (does not look flaky)
+      ExpectationFailed "Hspec had no more information about this failure."
+  
+    src/Test/Syd/Hspec.hs:68
+  ✗ 2 failure with reason
+      Retries: 3 (does not look flaky)
+      Contextual "ExpectationFailed \"failure reason\"" "test/Test/Syd/OutputSpec.hs:34:30"
+  
+    src/Test/Syd/Hspec.hs:68
+  ✗ 3 failure with "expected x but got y"
+      Retries: 3 (does not look flaky)
+      Expected these values to be equal:
+      Actual:   8
+      Expected: 6
+  
+    src/Test/Syd/Hspec.hs:68
+  ✗ 4 failure with error
+      Retries: 3 (does not look flaky)
+      error msg
+  
+
+  Examples:                     12
+  Passed:                       0
+  Failed:                       4
+  Sum of test runtimes:         0.00 seconds
+  Test suite took:              0.00 seconds
+


### PR DESCRIPTION
Fixes #103. When using `fromHspec`, the failure output (when using `shouldBe`) now looks like this:

```
Failures:                                                                                                                      
                                                                                                                               
    src/Test/Syd/Hspec.hs:68                                                                                                   
  ✗ 1 Test.Syd.HspecSpec.exampleHspecSpec.adds 3 and 5 together in io   
      Retries: 3 (does not look flaky)                                                                                         
      Expected these values to be equal:                      
      Actual:   8                                                                                                              
      Expected: 6   
```