### PR TITLE
refactor: Store Text instead of String inside assertion

### DIFF
--- a/sydtest-test/test/Test/Syd/DiffSpec.hs
+++ b/sydtest-test/test/Test/Syd/DiffSpec.hs
@@ -287,6 +287,6 @@ spec = do
 
   describe "outputEqualityAssertionFailed" $ do
     it "can output a large diff quickly enough" $
-      let a = replicate 10000 'a'
+      let a = T.replicate 10000 "a"
           b = "b"
        in length (outputEqualityAssertionFailed a b (Just $ computeDiff a b)) `shouldBe` 3

--- a/sydtest/src/Test/Syd/Def/Golden.hs
+++ b/sydtest/src/Test/Syd/Def/Golden.hs
@@ -163,5 +163,5 @@ goldenPrettyShowInstance fp a = pureGoldenStringFile fp (ppShow a)
 -- >   if actual == expected
 -- >     then Nothing
 -- >     else Just $ Context (stringsNotEqualButShouldHaveBeenEqual actual expected) (goldenContext fp)
-goldenContext :: FilePath -> String
-goldenContext fp = "The golden results are in: " <> fp
+goldenContext :: FilePath -> Text
+goldenContext fp = T.pack $ "The golden results are in: " <> fp

--- a/sydtest/src/Test/Syd/Expectation.hs
+++ b/sydtest/src/Test/Syd/Expectation.hs
@@ -29,41 +29,41 @@ import Text.Show.Pretty
 
 -- | Assert that two values are equal according to `==`.
 shouldBe :: (HasCallStack, Show a, Eq a) => a -> a -> IO ()
-shouldBe actual expected = unless (actual == expected) $ throwIO =<< mkNotEqualButShouldHaveBeenEqual (ppShow actual) (ppShow expected)
+shouldBe actual expected = unless (actual == expected) $ throwIO =<< mkNotEqualButShouldHaveBeenEqual (T.pack $ ppShow actual) (T.pack $ ppShow expected)
 
 infix 1 `shouldBe`
 
 -- | Assert that two values are not equal according to `==`.
 shouldNotBe :: (HasCallStack, Show a, Eq a) => a -> a -> IO ()
-shouldNotBe actual expected = unless (actual /= expected) $ throwIO $ EqualButShouldNotHaveBeenEqual (ppShow actual) (ppShow expected)
+shouldNotBe actual expected = unless (actual /= expected) $ throwIO $ EqualButShouldNotHaveBeenEqual (T.pack $ ppShow actual) (T.pack $ ppShow expected)
 
 infix 1 `shouldNotBe`
 
 -- | Assert that a value satisfies the given predicate.
 shouldSatisfy :: (HasCallStack, Show a) => a -> (a -> Bool) -> IO ()
-shouldSatisfy actual p = unless (p actual) $ throwIO $ PredicateFailedButShouldHaveSucceeded (ppShow actual) Nothing
+shouldSatisfy actual p = unless (p actual) $ throwIO $ PredicateFailedButShouldHaveSucceeded (T.pack $ ppShow actual) Nothing
 
 -- | Assert that a value satisfies the given predicate with the given predicate name.
 shouldSatisfyNamed :: (HasCallStack, Show a) => a -> String -> (a -> Bool) -> IO ()
-shouldSatisfyNamed actual name p = unless (p actual) $ throwIO $ PredicateFailedButShouldHaveSucceeded (ppShow actual) (Just name)
+shouldSatisfyNamed actual name p = unless (p actual) $ throwIO $ PredicateFailedButShouldHaveSucceeded (T.pack $ ppShow actual) (Just $ T.pack name)
 
 infix 1 `shouldSatisfy`
 
 -- | Assert that a value does not satisfy the given predicate.
 shouldNotSatisfy :: (HasCallStack, Show a) => a -> (a -> Bool) -> IO ()
-shouldNotSatisfy actual p = when (p actual) $ throwIO $ PredicateSucceededButShouldHaveFailed (ppShow actual) Nothing
+shouldNotSatisfy actual p = when (p actual) $ throwIO $ PredicateSucceededButShouldHaveFailed (T.pack $ ppShow actual) Nothing
 
 infix 1 `shouldNotSatisfy`
 
 -- | Assert that a value does not satisfy the given predicate with the given predicate name.
 shouldNotSatisfyNamed :: (HasCallStack, Show a) => a -> String -> (a -> Bool) -> IO ()
-shouldNotSatisfyNamed actual name p = when (p actual) $ throwIO $ PredicateSucceededButShouldHaveFailed (ppShow actual) (Just name)
+shouldNotSatisfyNamed actual name p = when (p actual) $ throwIO $ PredicateSucceededButShouldHaveFailed (T.pack $ ppShow actual) (Just $ T.pack name)
 
 -- | Assert that computation returns the given value (according to `==`).
 shouldReturn :: (HasCallStack, Show a, Eq a) => IO a -> a -> IO ()
 shouldReturn computeActual expected = do
   actual <- computeActual
-  unless (actual == expected) $ throwIO =<< mkNotEqualButShouldHaveBeenEqual (ppShow actual) (ppShow expected)
+  unless (actual == expected) $ throwIO =<< mkNotEqualButShouldHaveBeenEqual (T.pack $ ppShow actual) (T.pack $ ppShow expected)
 
 infix 1 `shouldReturn`
 
@@ -71,7 +71,7 @@ infix 1 `shouldReturn`
 shouldNotReturn :: (HasCallStack, Show a, Eq a) => IO a -> a -> IO ()
 shouldNotReturn computeActual expected = do
   actual <- computeActual
-  unless (actual /= expected) $ throwIO $ EqualButShouldNotHaveBeenEqual (ppShow actual) (ppShow expected)
+  unless (actual /= expected) $ throwIO $ EqualButShouldNotHaveBeenEqual (T.pack $ ppShow actual) (T.pack $ ppShow expected)
 
 infix 1 `shouldNotReturn`
 
@@ -119,25 +119,25 @@ textShouldBe actual expected = unless (actual == expected) $ throwIO =<< textsNo
 -- Note that using function could mess up the colours in your terminal if the Texts contain ANSI codes.
 -- In that case you may want to `show` your values first or use `shouldBe` instead.
 stringsNotEqualButShouldHaveBeenEqual :: String -> String -> IO Assertion
-stringsNotEqualButShouldHaveBeenEqual actual expected = mkNotEqualButShouldHaveBeenEqual actual expected
+stringsNotEqualButShouldHaveBeenEqual actual expected = mkNotEqualButShouldHaveBeenEqual (T.pack actual) (T.pack expected)
 
 -- | An assertion that says two 'Text's should have been equal according to `==`.
 --
 -- Note that using function could mess up the colours in your terminal if the Texts contain ANSI codes.
 -- In that case you may want to `show` your values first or use `shouldBe` instead.
 textsNotEqualButShouldHaveBeenEqual :: Text -> Text -> IO Assertion
-textsNotEqualButShouldHaveBeenEqual actual expected = mkNotEqualButShouldHaveBeenEqual (T.unpack actual) (T.unpack expected)
+textsNotEqualButShouldHaveBeenEqual actual expected = mkNotEqualButShouldHaveBeenEqual actual expected
 
 -- | An assertion that says two 'ByteString's should have been equal according to `==`.
 bytestringsNotEqualButShouldHaveBeenEqual :: ByteString -> ByteString -> IO Assertion
-bytestringsNotEqualButShouldHaveBeenEqual actual expected = mkNotEqualButShouldHaveBeenEqual (show actual) (show expected)
+bytestringsNotEqualButShouldHaveBeenEqual actual expected = mkNotEqualButShouldHaveBeenEqual (T.pack $ show actual) (T.pack $ show expected)
 
 -- | Make a test fail
 --
 -- Note that this is mostly backward compatible, but it has return type 'a' instead of '()' because execution will not continue beyond this function.
 -- In this way it is not entirely backward compatible with hspec because now there could be an ambiguous type error.
 expectationFailure :: (HasCallStack) => String -> IO a
-expectationFailure = throwIO . ExpectationFailed
+expectationFailure = throwIO . ExpectationFailed . T.pack
 
 -- | Annotate a given action with a context, for contextual assertions
 --

--- a/sydtest/src/Test/Syd/Run.hs
+++ b/sydtest/src/Test/Syd/Run.hs
@@ -25,7 +25,6 @@ import Data.IORef
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Text (Text)
-import qualified Data.Text as T
 import qualified Data.Vector as V
 import Data.Word
 import GHC.Clock (getMonotonicTimeNSec)
@@ -494,16 +493,16 @@ data TestStatus = TestPassed | TestFailed
 data Assertion
   = -- | Both strings are not equal. The latest argument is a diff between both
     -- arguments. If `Nothing`, the raw values will be displayed instead of the diff.
-    NotEqualButShouldHaveBeenEqualWithDiff !String !String !(Maybe [Diff Text])
-  | EqualButShouldNotHaveBeenEqual !String !String
+    NotEqualButShouldHaveBeenEqualWithDiff !Text !Text !(Maybe (V.Vector (Diff Text)))
+  | EqualButShouldNotHaveBeenEqual !Text !Text
   | PredicateSucceededButShouldHaveFailed
-      !String -- Value
-      !(Maybe String) -- Name of the predicate
+      !Text -- Value
+      !(Maybe Text) -- Name of the predicate
   | PredicateFailedButShouldHaveSucceeded
-      !String -- Value
-      !(Maybe String) -- Name of the predicate
-  | ExpectationFailed !String
-  | Context !Assertion !String
+      !Text -- Value
+      !(Maybe Text) -- Name of the predicate
+  | ExpectationFailed !Text
+  | Context !Assertion !Text
   deriving (Show, Eq, Generic)
 
 -- | Returns the diff between two strings
@@ -512,14 +511,14 @@ data Assertion
 -- time (hours) if the input strings are complex. This is exposed for
 -- reference, but you may want to use 'mkNotEqualButShouldHaveBeenEqual' which
 -- ensures that diff computation timeouts.
-computeDiff :: String -> String -> [Diff Text]
-computeDiff a b = V.toList $ getTextDiff (T.pack a) (T.pack b)
+computeDiff :: Text -> Text -> V.Vector (Diff Text)
+computeDiff a b = getTextDiff a b
 
 -- | Assertion when both arguments are not equal. While display a diff between
 -- both at the end of tests. The diff computation is cancelled after 2s.
 mkNotEqualButShouldHaveBeenEqual ::
-  String ->
-  String ->
+  Text ->
+  Text ->
   IO Assertion
 mkNotEqualButShouldHaveBeenEqual actual expected = do
   let diffNotEvaluated = computeDiff actual expected


### PR DESCRIPTION
On `sydtest-test`, the difference is:

```
- 657 MiB total memory in use
+ 358 MiB total memory in use
```

This is actually surprising (e.g. that the numbers are so good) because it should only save space on failing test. I'm also unable to replicate similar numbers on a large codebase (e.g. this commit reduced my memory usage from 2.750 GiB during test to 2.720.

Mainly the changes are that in all Assertion, we store `Text` instead of `String`. Note that final benchmark should show a bit more allocations (e.g. during conversion from `ppShow` `String` to `Text`), but then it should show less copy and less total memory usage.