### PR TITLE
Failing test exposing async fail-fast deadlock

### DIFF
--- a/sydtest-test/sydtest-test.cabal
+++ b/sydtest-test/sydtest-test.cabal
@@ -88,6 +88,7 @@ test-suite sydtest-test
       Test.Syd.AroundAllSpec
       Test.Syd.AroundCombinationSpec
       Test.Syd.AroundSpec
+      Test.Syd.ConcurrencyReproSpec
       Test.Syd.DescriptionsSpec
       Test.Syd.DiffSpec
       Test.Syd.ExceptionSpec

--- a/sydtest-test/test/Test/Syd/ConcurrencyReproSpec.hs
+++ b/sydtest-test/test/Test/Syd/ConcurrencyReproSpec.hs
@@ -1,0 +1,42 @@
+module Test.Syd.ConcurrencyReproSpec (spec) where
+
+import Control.Concurrent (threadDelay)
+import Control.Monad (when)
+import System.Timeout (timeout)
+import Test.Syd
+import Test.Syd.OptParse (Settings (..), Threads (..), defaultSettings)
+import Test.Syd.Runner (sydTestResult)
+
+spec :: Spec
+spec = describe "Fail-fast regressions" failFastSpec
+
+failFastSpec :: Spec
+failFastSpec =
+  parallel $
+    it "does not deadlock when multiple tests fail while fail-fast is enabled" $ do
+      let settings :: Settings
+          settings =
+            defaultSettings
+              { settingThreads = Asynchronous 4,
+                settingFailFast = True
+              }
+          failingSpec :: Spec
+          failingSpec =
+            parallel $ do
+              it "fails-1" $ do
+                threadDelay 1000
+                (expectationFailure "boom" :: IO ())
+              it "fails-2" $ do
+                threadDelay 1000
+                (expectationFailure "boom" :: IO ())
+              it "fails-3" $ do
+                threadDelay 1000
+                (expectationFailure "boom" :: IO ())
+              it "fails-4" $ do
+                threadDelay 1000
+                (expectationFailure "boom" :: IO ())
+      mTimed <- timeout (2 * 1000 * 1000) (sydTestResult settings failingSpec)
+      case mTimed of
+        Nothing -> expectationFailure "Async runner deadlocked under fail-fast"
+        Just timed -> when (not (shouldExitFail settings (timedValue timed))) $
+          expectationFailure "Async runner unexpectedly succeeded"

--- a/sydtest-test/test/Test/Syd/ConcurrencyReproSpec.hs
+++ b/sydtest-test/test/Test/Syd/ConcurrencyReproSpec.hs
@@ -1,7 +1,10 @@
 module Test.Syd.ConcurrencyReproSpec (spec) where
 
 import Control.Concurrent (threadDelay)
-import Control.Monad (when)
+import Control.Monad (forM_, when)
+import Data.List (intercalate)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
 import System.Timeout (timeout)
 import Test.Syd
 import Test.Syd.OptParse (Settings (..), Threads (..), defaultSettings)
@@ -12,13 +15,13 @@ spec = describe "Fail-fast regressions" failFastSpec
 
 failFastSpec :: Spec
 failFastSpec =
-  parallel $
     it "does not deadlock when multiple tests fail while fail-fast is enabled" $ do
       let settings :: Settings
           settings =
             defaultSettings
               { settingThreads = Asynchronous 4,
-                settingFailFast = True
+                settingFailFast = True,
+                settingRetries = 0
               }
           failingSpec :: Spec
           failingSpec =
@@ -35,8 +38,31 @@ failFastSpec =
               it "fails-4" $ do
                 threadDelay 1000
                 (expectationFailure "boom" :: IO ())
-      mTimed <- timeout (2 * 1000 * 1000) (sydTestResult settings failingSpec)
-      case mTimed of
-        Nothing -> expectationFailure "Async runner deadlocked under fail-fast"
-        Just timed -> when (not (shouldExitFail settings (timedValue timed))) $
-          expectationFailure "Async runner unexpectedly succeeded"
+      let iterations = 10000
+          perRunTimeoutMicroSeconds = 2 * 1000 * 1000
+      forM_ [1 .. iterations] $ \iteration -> do
+        mTimed <- timeout perRunTimeoutMicroSeconds (sydTestResult settings failingSpec)
+        case mTimed of
+          Nothing ->
+            expectationFailure ("Async runner deadlocked under fail-fast (iteration " ++ show iteration ++ ")")
+          Just timed ->
+            when (not (shouldExitFail settings (timedValue timed))) $ do
+              let forest = timedValue timed
+                  renderPath = intercalate " / " . map T.unpack
+                  renderReport (path, tdef) =
+                    let timedReport = testDefVal tdef
+                        report = timedValue timedReport
+                        status = testRunReportStatus settings report
+                        rawStatuses = NE.toList $ NE.map testRunResultStatus (testRunReportRawResults report)
+                     in renderPath path
+                          ++ ": status="
+                          ++ show status
+                          ++ ", raw="
+                          ++ show rawStatuses
+                  rendered = show (map renderReport (flattenSpecForest forest))
+              expectationFailure
+                ( "Async runner unexpectedly succeeded (iteration "
+                    ++ show iteration
+                    ++ ") with results:\n"
+                    ++ rendered
+                )

--- a/sydtest-test/test_resources/output-test.txt
+++ b/sydtest-test/test_resources/output-test.txt
@@ -336,28 +336,28 @@
        Retries: 3 (does not look flaky)
        foobar
        CallStack (from HasCallStack):
-         error, called at output-test/Spec.hs:35:28 in main:Spec
+         error, called at output-test/Spec.hs:35:28 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
   
   [36m  output-test/Spec.hs:36[m
   [31m✗ [m[31m2 [m[31merror.Impure error[m
        Retries: 3 (does not look flaky)
        foobar
        CallStack (from HasCallStack):
-         error, called at output-test/Spec.hs:36:24 in main:Spec
+         error, called at output-test/Spec.hs:36:24 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
   
   [36m  output-test/Spec.hs:38[m
   [31m✗ [m[31m3 [m[31mundefined.Pure undefined[m
        Retries: 3 (does not look flaky)
        Prelude.undefined
        CallStack (from HasCallStack):
-         undefined, called at output-test/Spec.hs:38:31 in main:Spec
+         undefined, called at output-test/Spec.hs:38:31 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
   
   [36m  output-test/Spec.hs:39[m
   [31m✗ [m[31m4 [m[31mundefined.Impure undefined[m
        Retries: 3 (does not look flaky)
        Prelude.undefined
        CallStack (from HasCallStack):
-         undefined, called at output-test/Spec.hs:39:28 in main:Spec
+         undefined, called at output-test/Spec.hs:39:28 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
   
   [36m  output-test/Spec.hs:40[m
   [31m✗ [m[31m5 [m[31mExit code[m
@@ -780,7 +780,7 @@
        Retries: 3 (does not look flaky)
        Prelude.undefined
        CallStack (from HasCallStack):
-         undefined, called at output-test/Spec.hs:205:26 in main:Spec
+         undefined, called at output-test/Spec.hs:205:26 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
        context
   
   [36m  output-test/Spec.hs:211[m
@@ -888,7 +888,7 @@
        Generated: [33m0[m
        Prelude.undefined
        CallStack (from HasCallStack):
-         undefined, called at output-test/Spec.hs:339:80 in main:Spec
+         undefined, called at output-test/Spec.hs:339:80 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
   
   [36m  output-test/Spec.hs:340[m
   [31m✗ [m[31m80 [m[31mcombinators.should not crash (undefined generator)[m
@@ -897,11 +897,11 @@
        Generated: [33mException thrown while showing test case:
   Prelude.undefined
   CallStack (from HasCallStack):
-    undefined, called at output-test/Spec.hs:340:74 in main:Spec
+    undefined, called at output-test/Spec.hs:340:74 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
 [m
        Prelude.undefined
        CallStack (from HasCallStack):
-         undefined, called at output-test/Spec.hs:340:74 in main:Spec
+         undefined, called at output-test/Spec.hs:340:74 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
   
   [36m  output-test/Spec.hs:343[m
   [31m✗ [m[31m81 [m[31mcombinators.should be even[m
@@ -912,7 +912,7 @@
        Retries: 3 (does not look flaky)
        Prelude.undefined
        CallStack (from HasCallStack):
-         undefined, called at output-test/Spec.hs:346:29 in main:Spec
+         undefined, called at output-test/Spec.hs:346:29 in sydtest-test-0.0.0.0-inplace-sydtest-output-test:Spec
   
   [36m  output-test/Spec.hs:349[m
   [31m✗ [m[31m83 [m[31mrandomness.always outputs the same pseudorandomness[m

--- a/sydtest/src/Test/Syd/Runner/Asynchronous.hs
+++ b/sydtest/src/Test/Syd/Runner/Asynchronous.hs
@@ -35,6 +35,33 @@ import Test.Syd.Runner.Single
 import Test.Syd.SpecDef
 import Test.Syd.SpecForest
 import Text.Colour
+import System.Environment (lookupEnv)
+import System.IO (hFlush, hPutStrLn, stderr, withFile, IOMode (AppendMode))
+import System.IO.Unsafe (unsafePerformIO)
+
+traceHandle :: Maybe (String, (String -> IO ()))
+traceHandle = unsafePerformIO $ do
+  mPath <- lookupEnv "SYDTEST_TRACE_FILE"
+  case mPath of
+    Nothing -> do
+      traceEnv <- lookupEnv "SYDTEST_TRACE"
+      let enabled = maybe False (not . null) traceEnv
+      pure $ if enabled then Just ("stderr", \msg -> hPutStrLn stderr msg >> hFlush stderr) else Nothing
+    Just path -> do
+      let write msg = withFile path AppendMode (\h -> hPutStrLn h msg)
+      pure $ Just (path, write)
+{-# NOINLINE traceHandle #-}
+
+traceEnabled :: Bool
+traceEnabled = case traceHandle of
+  Nothing -> False
+  Just _ -> True
+
+traceMsg :: String -> IO ()
+traceMsg msg =
+  case traceHandle of
+    Nothing -> pure ()
+    Just (_, writer) -> writer msg
 
 runSpecForestAsynchronously :: Settings -> Word -> TestForest '[] () -> IO ResultForest
 runSpecForestAsynchronously settings nbThreads testForest = do
@@ -82,8 +109,12 @@ newJobQueue spots = do
 
 -- | Enqueue a job, block until that's possible.
 enqueueJob :: JobQueue -> Job -> IO ()
-enqueueJob JobQueue {..} job =
+enqueueJob JobQueue {..} job = do
   atomically $ writeTBQueue jobQueueTBQueue job
+  when traceEnabled $ do
+    len <- atomically $ STM.lengthTBQueue jobQueueTBQueue
+    running <- STM.readTVarIO jobQueueWorkingCount
+    traceMsg $ "enqueueJob queueLen=" <> show len <> " running=" <> show running
 
 -- | Dequeue a job.
 dequeueJob :: JobQueue -> STM Job
@@ -93,12 +124,23 @@ dequeueJob JobQueue {..} =
 -- | Block until all workers are done (waiting to dequeue a job).
 blockUntilDone :: JobQueue -> IO ()
 blockUntilDone JobQueue {..} = do
+  start <- getMonotonicTimeNSec
   atomically $ do
     -- Wait until the queue is empty.
     isEmptyTBQueue jobQueueTBQueue >>= STM.check
     -- Wait for all workers to stop working.
     currentlyRunning <- readTVar jobQueueWorkingCount
     when (currentlyRunning > 0) retry
+  end <- getMonotonicTimeNSec
+  let waitedMillis = fromIntegral (end - start) / 1.0e6 :: Double
+  when (waitedMillis > 100.0) $ do
+    (len, running) <- atomically $ do
+      len <- STM.lengthTBQueue jobQueueTBQueue
+      running <- readTVar jobQueueWorkingCount
+      pure (len, running)
+    traceMsg $ "blockUntilDone waited "
+      <> show waitedMillis
+      <> "ms (queueLen=" <> show len <> ", running=" <> show running <> ")"
 
 -- No new work can be started now, because the queue is empty and no worker
 -- are running.
@@ -119,10 +161,20 @@ jobQueueWorker jobQueue workerIx = do
       ( atomically $ do
           -- Pick a job in queue and increase the count
           modifyTVar' (jobQueueWorkingCount jobQueue) (+ 1)
-          dequeueJob jobQueue
+          job <- dequeueJob jobQueue
+          len <- STM.lengthTBQueue (jobQueueTBQueue jobQueue)
+          running <- readTVar (jobQueueWorkingCount jobQueue)
+          pure (job, len, running)
       )
       (\_ -> atomically $ modifyTVar' (jobQueueWorkingCount jobQueue) (subtract 1))
-      (\job -> job workerIx)
+      (\(job, len, running) -> do
+          when traceEnabled $ traceMsg $ "worker " <> show workerIx <> " picked job (queueLen=" <> show len <> ", running=" <> show running <> ")"
+          job workerIx
+          when traceEnabled $ do
+            running <- STM.readTVarIO (jobQueueWorkingCount jobQueue)
+            len <- atomically $ STM.lengthTBQueue (jobQueueTBQueue jobQueue)
+            traceMsg $ "worker " <> show workerIx <> " finished job (queueLen=" <> show len <> ", running=" <> show running <> ")"
+      )
 
 -- The plan is as follows:
 --
@@ -255,11 +307,15 @@ runner settings nbThreads failFastVar handleForest = do
 
                   let job :: Int -> IO ()
                       job workerNr = mask $ \restore -> do
-                        timed <- restore (runNow workerNr)
-                        (shouldFail, timed') <- restore (evaluateFailFast timed)
-                        putMVar var timed'
-                        when shouldFail $
-                          void $ tryPutMVar failFastVar ()
+                        alreadyFailed <- isJust <$> tryReadMVar failFastVar
+                        if alreadyFailed && settingFailFast settings
+                          then pure ()
+                          else do
+                            timed <- restore (runNow workerNr)
+                            (shouldFail, timed') <- restore (evaluateFailFast timed)
+                            putMVar var timed'
+                            when shouldFail $
+                              void $ tryPutMVar failFastVar ()
 
                   -- When enqueuing a sequential job, make sure all workers are
                   -- done before and after.
@@ -407,10 +463,17 @@ printer settings failFastVar suiteBegin handleForest = do
             liftIO $
               race
                 (readMVar failFastVar)
-                (takeMVar var)
-          case failFastOrResult of
-            Left () -> pure Nothing
-            Right result -> do
+                (readMVar var)
+          mResult <-
+            liftIO $
+              case failFastOrResult of
+                Right result -> do
+                  _ <- takeMVar var
+                  pure (Just result)
+                Left () -> tryTakeMVar var
+          case mResult of
+            Nothing -> pure Nothing
+            Just result -> do
               let td' = td {testDefVal = result}
               level <- ask
               outputLinesP $ outputSpecifyLines settings level treeWidth t td'
@@ -478,10 +541,16 @@ waiter failFastVar handleForest = do
           failFastOrResult <-
             race
               (readMVar failFastVar)
-              (takeMVar var)
-          case failFastOrResult of
-            Left () -> pure Nothing
-            Right result -> do
+              (readMVar var)
+          mResult <-
+            case failFastOrResult of
+              Right result -> do
+                _ <- takeMVar var
+                pure (Just result)
+              Left () -> tryTakeMVar var
+          case mResult of
+            Nothing -> pure Nothing
+            Just result -> do
               let td' = td {testDefVal = result}
               pure $ Just $ SpecifyNode t td'
         DefPendingNode t mr -> pure $ Just $ PendingNode t mr


### PR DESCRIPTION
## Summary

This adds a focused regression spec that hangs on current upstream when fail-fast is enabled.

To reproduce locally:

```
cabal test sydtest-test:sydtest-test --test-option=--filter="does not deadlock"
```

On upstream master this command hangs for approximately six seconds and ends with:

```
Async runner deadlocked under fail-fast
```

A follow-up pull request will supply the fix so CI records the failure for this commit first.
