### PR TITLE
Fix: ignore filter does not suppress RemoveAction on ignored do-block statements

### DIFF
--- a/nix/mutation.yaml
+++ b/nix/mutation.yaml
@@ -13,3 +13,4 @@ debug: true
 # 'ExpandedThingTc' node).
 ignore:
   - mark
+  - markM

--- a/sydtest-mutation-example/src/Example/IgnoreLib.hs
+++ b/sydtest-mutation-example/src/Example/IgnoreLib.hs
@@ -2,8 +2,12 @@ module Example.IgnoreLib
   ( mark,
     markPlain,
     markDollar,
+    markM,
+    markAction,
   )
 where
+
+import Control.Monad.Writer (Writer, execWriter, tell)
 
 -- | A two-argument no-op marker with a polymorphic payload.  Listed
 -- under 'ignore:' in the plugin config so mutations are suppressed at
@@ -25,3 +29,23 @@ markPlain = mark "tag" (unwords ["a", "b", "c"])
 -- the list literal in the second argument.
 markDollar :: String
 markDollar = mark "tag" $ unwords ["a", "b", "c"]
+
+-- | A no-op marker action, the monadic analogue of 'mark'.  Listed under
+-- 'ignore:' so a @do@-block statement @markM "..."@ is left alone.
+--
+-- This is the @logDebug "..."@ shape: an ignored call used as a
+-- non-binding @do@-block statement.  GHC 9.10 expands
+-- @do { markM "x"; rest }@ into @(>>) (markM "x") rest@, whose head is
+-- @(>>)@, not @markM@.  The 'RemoveAction' operator matches the @(>>)@
+-- chain and would otherwise drop the @markM "x"@ action — even though
+-- @markM@ is ignored.  The ignore machinery must suppress that removal.
+markM :: String -> Writer String ()
+markM _ = pure ()
+
+-- | A @do@-block that uses 'markM' (ignored) as a non-binding statement.
+-- No mutation may be produced for the @markM "..."@ action, including the
+-- 'RemoveAction' that would drop the statement entirely.
+markAction :: String
+markAction = execWriter $ do
+  markM "tag"
+  tell "body"

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Instrument.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Instrument.hs
@@ -726,18 +726,25 @@ applyOperator origExpr fallthrough op = case operatorMatch op origExpr of
   Nothing -> pure fallthrough
   Just action -> do
     alts <- action
-    hscEnv <- liftTcM getTopEnv
-    validated <- liftTcM $ filterM (liftIO . validateAlt hscEnv) alts
-    case validated of
-      [] -> do
-        liftTcM $
-          liftIO $
-            putStrLn $
-              "mutation: WARNING all replacements dropped for operator "
-                ++ operatorName op
-                ++ locStr (getLocA origExpr)
-        pure fallthrough
-      (x : xs) -> applyAlts (operatorName op) (x :| xs) fallthrough
+    case alts of
+      -- The operator's action chose to produce no alternatives (e.g.
+      -- RemoveAction declining to remove an action whose head is on the
+      -- 'ignore' list).  This is a deliberate non-candidate, not a
+      -- validation failure, so it must be silent.
+      [] -> pure fallthrough
+      _ -> do
+        hscEnv <- liftTcM getTopEnv
+        validated <- liftTcM $ filterM (liftIO . validateAlt hscEnv) alts
+        case validated of
+          [] -> do
+            liftTcM $
+              liftIO $
+                putStrLn $
+                  "mutation: WARNING all replacements dropped for operator "
+                    ++ operatorName op
+                    ++ locStr (getLocA origExpr)
+            pure fallthrough
+          (x : xs) -> applyAlts (operatorName op) (x :| xs) fallthrough
 
 validateAlt :: HscEnv -> (Type, LHsExpr GhcTc, String, String, SrcSpanDelta) -> IO Bool
 validateAlt hscEnv (_, mutated, _, _, _) = do

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/RemoveAction.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/RemoveAction.hs
@@ -2,9 +2,10 @@
 
 module Test.Syd.Mutation.Plugin.Operator.RemoveAction (theOperator) where
 
+import Control.Monad.Reader (asks)
 import GHC
 import GHC.Hs.Syn.Type (lhsExprType)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, MutationOperator (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), SrcSpanDelta (..))
 import Test.Syd.Mutation.Plugin.Operator.Util (opOccName)
 
 -- | Remove one non-binding action from a do block.
@@ -48,23 +49,38 @@ viewThenChain le = case unLoc le of
   _ -> Nothing
 
 -- | Build the mutation: replace @lhs >> rest@ with just @rest@.
+--
+-- Suppressed when @lhs@'s syntactic head is on the @ignore@ list: removing
+-- e.g. @logDebug "x"@ from @do { logDebug "x"; rest }@ is exactly the noise
+-- the ignore filter exists to silence.  The filter in 'instrumentLExpr'
+-- cannot catch this on its own because GHC 9.10 has expanded the do-block
+-- into @(>>) lhs rest@, whose head is @(>>)@, not the ignored name — so we
+-- check the removed action's head here instead.  Returning @[]@ makes
+-- 'applyOperator' treat the site as a non-candidate (no warning, no mutant).
 mutateChain ::
   Type ->
   LHsExpr GhcTc ->
   LHsExpr GhcTc ->
   InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
-mutateChain ty lhs rest =
-  let removedSpan = case getLocA lhs of
-        RealSrcSpan rss _ -> [rss]
-        UnhelpfulSpan _ -> []
-   in pure
-        [ ( ty,
-            rest,
-            "a >> rest",
-            "rest",
-            SpanRemoval removedSpan
-          )
-        ]
+mutateChain ty lhs rest = do
+  ignore <- asks instrumentEnvIgnore
+  let lhsIgnored = case opOccName lhs of
+        Just occ -> occ `elem` ignore
+        Nothing -> False
+  if lhsIgnored
+    then pure []
+    else
+      let removedSpan = case getLocA lhs of
+            RealSrcSpan rss _ -> [rss]
+            UnhelpfulSpan _ -> []
+       in pure
+            [ ( ty,
+                rest,
+                "a >> rest",
+                "rest",
+                SpanRemoval removedSpan
+              )
+            ]
 
 -- | Fallback: also support @HsDo@ if it ever shows up unexpanded
 -- (e.g. list comprehensions, arrow notation), since the original
@@ -83,6 +99,12 @@ isRemovableStmt (L _ s) = case s of
   BodyStmt {} -> True
   _ -> False
 
+-- | The expression of a 'BodyStmt', if this statement is one.
+bodyStmtExpr :: ExprLStmt GhcTc -> Maybe (LHsExpr GhcTc)
+bodyStmtExpr (L _ s) = case s of
+  BodyStmt _ e _ _ -> Just e
+  _ -> Nothing
+
 rawDoAction ::
   SrcSpanAnnA ->
   XDo GhcTc ->
@@ -91,8 +113,16 @@ rawDoAction ::
   [ExprLStmt GhcTc] ->
   Type ->
   InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
-rawDoAction ann x ctx lann stmts ty =
-  let removable = [(i, s) | (i, s) <- zip [0 ..] stmts, isRemovableStmt s]
+rawDoAction ann x ctx lann stmts ty = do
+  -- Do not offer to remove a statement whose head is on the 'ignore' list:
+  -- removing @logDebug "x"@ and the like is the noise the ignore filter
+  -- exists to silence.  Mirrors the guard in 'mutateChain' for the expanded
+  -- @(>>)@ form.
+  ignore <- asks instrumentEnvIgnore
+  let stmtIgnored s = case bodyStmtExpr s >>= opOccName of
+        Just occ -> occ `elem` ignore
+        Nothing -> False
+      removable = [(i, s) | (i, s) <- zip [0 ..] stmts, isRemovableStmt s, not (stmtIgnored s)]
       n = length stmts
       mkMutation i s =
         let stmts' = take i stmts ++ drop (i + 1) stmts
@@ -105,4 +135,4 @@ rawDoAction ann x ctx lann stmts ty =
               show (n - 1) ++ " statements (removed #" ++ show (i + 1) ++ ")",
               SpanRemoval removedSpan
             )
-   in pure [mkMutation i s | (i, s) <- removable]
+  pure [mkMutation i s | (i, s) <- removable]


### PR DESCRIPTION
## Summary of the bug

The mutation plugin's `ignore` config (e.g. `ignore: [logDebug, logInfo]`) is
supposed to leave certain calls — and their argument subtrees — completely
untouched. But mutations were still generated for ignored calls used as
`do`-block statements. In `~/src/nix-ci` these surfaced as `RemoveAction`
mutations dropping statements like:

- `forPrometheus prometheusEnvCounterBytesPut $ liftIO . Counter.add (SB.length contents)`
- `logDebug $ Text.pack $ unwords [...]`
- `logDebug "Unauthenticated request"`

## The regression test

`sydtest-mutation-example/src/Example/IgnoreLib.hs` gains `markM` (a no-op
`Writer` action, the monadic analogue of the existing `mark` marker) and a
`markAction` `do`-block that uses it as a non-binding statement:

```haskell
markAction = execWriter $ do
  markM "tag"
  tell "body"
```

`markM` is added to the `ignore:` list in `nix/mutation.yaml`. The golden
manifest `Example.IgnoreLib.json` asserts no mutations (`[]`). Before the fix,
the golden manifest check (`checks.x86_64-linux.mutation-manifest-example`)
fails, producing a `RemoveAction` mutation that removes the ignored
`markM "tag"` statement.

## Root cause

The `ignore` filter in `instrumentLExpr` only checks the syntactic head of the
*current* expression. GHC 9.10 expands `do { logDebug "x"; rest }` into
`(>>) (logDebug "x") rest`, whose head is `(>>)` — not `logDebug` — so the
filter does not fire. The `RemoveAction` operator then matches the `(>>)` chain
and removes its LHS action (`logDebug "x"`), which is exactly the noise the
ignore list is meant to silence.

## The fix

`RemoveAction` now consults `instrumentEnvIgnore` and declines to remove an
action whose syntactic head is on the ignore list, in both code paths:

- `mutateChain` — the expanded `(>>) lhs rest` form (the common GHC 9.10 case).
- `rawDoAction` — the raw `HsDo` fallback (list/monad comprehensions).

To keep this silent, `applyOperator` in `Instrument.hs` now treats an operator
action that returns no alternatives as a deliberate non-candidate rather than a
validation failure, so it no longer prints the "all replacements dropped"
warning in this case.

Non-ignored removals are unaffected: `Example.DoLib`'s `RemoveAction` mutations
are unchanged.

## Things to manually check

- In `~/src/nix-ci`, add the relevant names (e.g. `logDebug`, `logInfo`,
  `forPrometheus`) to the `ignore:` list in `mutation.yaml` — the plugin still
  only ignores names that are explicitly configured; there is no built-in
  default ignore list. The three reported sites are all `do`-block statements
  that this fix now suppresses once their head is listed.
- Confirm the mutation report for nix-ci no longer lists the `RemoveAction`
  survivors on those statements after listing their heads under `ignore:`.