### PR TITLE
Mutation testing: diff-runner fixes, per-operator plugin config, SB rename

### DIFF
--- a/nix/mutationCheck.nix
+++ b/nix/mutationCheck.nix
@@ -64,6 +64,14 @@
 #       OOM-ing on hosts where 'getNumCapabilities' is high but test suites
 #       spawn expensive per-test resources (e.g. tmp-postgres). Pass 'null'
 #       to fall back to the harness default of 'getNumCapabilities'.
+# - mutationJobs: maximum number of mutation children to run concurrently.
+#       Defaults to the same value as 'coverageJobs'. The mutation phase has
+#       the same contention hazard as coverage: at full core-count
+#       concurrency a per-test resource (e.g. tmp-postgres) flakes, which
+#       surfaces as a spuriously-failing test and therefore a FALSE KILL —
+#       non-reproducible and inconsistent with a lower-volume diff-scoped
+#       run. Cap it for the same reason you cap 'coverageJobs'. Pass 'null'
+#       to fall back to the harness default of 'getNumCapabilities'.
 # - coverageRetry: how many times to retry a failing coverage child before
 #       giving up. Defaults to the harness default (3). Useful when test
 #       suites flake on contended resources (e.g. tmp-postgres' port binding)
@@ -97,6 +105,9 @@
   # Passed to the driver via the YAML config's 'childMemLimit'.
 , testProcessMemLimit ? "4g"
 , coverageJobs ? 4
+  # Maximum number of mutation children to run concurrently during the
+  # mutation phase. Defaults to 'coverageJobs' (the same contention cap).
+, mutationJobs ? coverageJobs
 , coverageRetry ? null
   # Whether to enable fail-fast in the harness run. Defaults to false because
   # e2e checks want the full report (driven by assertMutationScore), and
@@ -220,6 +231,10 @@ let
   coverageJobsFlag =
     pkgs.lib.optionalString (coverageJobs != null)
       "--coverage-jobs=${toString coverageJobs}";
+
+  mutationJobsFlag =
+    pkgs.lib.optionalString (mutationJobs != null)
+      "--mutation-jobs=${toString mutationJobs}";
   coverageRetryFlag =
     pkgs.lib.optionalString (coverageRetry != null)
       "--coverage-retry=${toString coverageRetry}";
@@ -334,6 +349,7 @@ let
           --child-mem-limit=${testProcessMemLimit} \
           ${failFastFlag} \
           ${coverageJobsFlag} \
+          ${mutationJobsFlag} \
           ${coverageRetryFlag} \
           --mutation-augmented-manifest-dir=augmented \
           --out-dir="$out"
@@ -385,6 +401,7 @@ let
           (pkg: ''--coverage-dir="${perPackageCoverage pkg}"'')
           testPackages} \
         --child-mem-limit=${testProcessMemLimit} \
+        ${mutationJobsFlag} \
         "''${out_dir_args[@]}" \
         "$@"
     '';

--- a/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/ComponentsSpec.hs
+++ b/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/ComponentsSpec.hs
@@ -4,7 +4,7 @@
 module Test.Syd.Mutation.Driver.ComponentsSpec (spec) where
 
 import qualified Control.Exception as Exception
-import qualified Data.ByteString as B
+import qualified Data.ByteString as SB
 import Path
 import Path.IO (createDirIfMissing, doesFileExist, withSystemTempDir)
 import Test.Syd
@@ -23,7 +23,7 @@ spec = do
     it "returns executable names in declaration order" $
       withSystemTempDir "components-exes" $ \dir -> do
         let cabalFile = dir </> [relfile|pkg.cabal|]
-        B.writeFile (fromAbsFile cabalFile) $
+        SB.writeFile (fromAbsFile cabalFile) $
           mconcat
             [ "cabal-version: 2.0\n",
               "name: pkg\n",
@@ -42,7 +42,7 @@ spec = do
     it "returns test-suite names" $
       withSystemTempDir "components-tests" $ \dir -> do
         let cabalFile = dir </> [relfile|pkg.cabal|]
-        B.writeFile (fromAbsFile cabalFile) $
+        SB.writeFile (fromAbsFile cabalFile) $
           mconcat
             [ "cabal-version: 2.0\n",
               "name: pkg\n",
@@ -59,7 +59,7 @@ spec = do
     it "returns an empty list when the package declares no components of that kind" $
       withSystemTempDir "components-empty" $ \dir -> do
         let cabalFile = dir </> [relfile|pkg.cabal|]
-        B.writeFile (fromAbsFile cabalFile) $
+        SB.writeFile (fromAbsFile cabalFile) $
           mconcat
             [ "cabal-version: 2.0\n",
               "name: pkg\n",
@@ -79,7 +79,7 @@ spec = do
         let cabalFile = dir </> [relfile|pkg.cabal|]
             buildDir = dir </> [reldir|dist/build|]
             outDir = dir </> [reldir|out|]
-        B.writeFile (fromAbsFile cabalFile) $
+        SB.writeFile (fromAbsFile cabalFile) $
           mconcat
             [ "cabal-version: 2.0\n",
               "name: pkg\n",
@@ -94,14 +94,14 @@ spec = do
             ]
         createDirIfMissing True (buildDir </> [reldir|foo|])
         createDirIfMissing True (buildDir </> [reldir|bar|])
-        B.writeFile (fromAbsFile (buildDir </> [relfile|foo/foo|])) "FOO"
-        B.writeFile (fromAbsFile (buildDir </> [relfile|bar/bar|])) "BAR"
+        SB.writeFile (fromAbsFile (buildDir </> [relfile|foo/foo|])) "FOO"
+        SB.writeFile (fromAbsFile (buildDir </> [relfile|bar/bar|])) "BAR"
         runInstallComponentsWithBuildDir ComponentExecutables cabalFile buildDir outDir
         copiedFoo <- doesFileExist (outDir </> [relfile|foo|])
         copiedBar <- doesFileExist (outDir </> [relfile|bar|])
         copiedFoo `shouldBe` True
         copiedBar `shouldBe` True
-        fooBytes <- B.readFile (fromAbsFile (outDir </> [relfile|foo|]))
+        fooBytes <- SB.readFile (fromAbsFile (outDir </> [relfile|foo|]))
         fooBytes `shouldBe` "FOO"
 
     it "throws MissingBuiltComponent when a declared executable's binary is absent" $
@@ -109,7 +109,7 @@ spec = do
         let cabalFile = dir </> [relfile|pkg.cabal|]
             buildDir = dir </> [reldir|dist/build|]
             outDir = dir </> [reldir|out|]
-        B.writeFile (fromAbsFile cabalFile) $
+        SB.writeFile (fromAbsFile cabalFile) $
           mconcat
             [ "cabal-version: 2.0\n",
               "name: pkg\n",
@@ -131,7 +131,7 @@ spec = do
         let cabalFile = dir </> [relfile|pkg.cabal|]
             buildDir = dir </> [reldir|dist/build|]
             outDir = dir </> [reldir|nested/out|]
-        B.writeFile (fromAbsFile cabalFile) $
+        SB.writeFile (fromAbsFile cabalFile) $
           mconcat
             [ "cabal-version: 2.0\n",
               "name: pkg\n",
@@ -142,7 +142,7 @@ spec = do
               "  build-depends: base\n"
             ]
         createDirIfMissing True (buildDir </> [reldir|foo|])
-        B.writeFile (fromAbsFile (buildDir </> [relfile|foo/foo|])) "FOO"
+        SB.writeFile (fromAbsFile (buildDir </> [relfile|foo/foo|])) "FOO"
         runInstallComponentsWithBuildDir ComponentExecutables cabalFile buildDir outDir
         copied <- doesFileExist (outDir </> [relfile|foo|])
         copied `shouldBe` True
@@ -152,7 +152,7 @@ spec = do
         let cabalFile = dir </> [relfile|pkg.cabal|]
             buildDir = dir </> [reldir|dist/build|]
             outDir = dir </> [reldir|out|]
-        B.writeFile (fromAbsFile cabalFile) $
+        SB.writeFile (fromAbsFile cabalFile) $
           mconcat
             [ "cabal-version: 2.0\n",
               "name: pkg\n",
@@ -168,22 +168,22 @@ spec = do
     it "returns <pname>.cabal when it exists" $
       withSystemTempDir "find-preferred" $ \dir -> do
         let expected = dir </> [relfile|foo.cabal|]
-        B.writeFile (fromAbsFile expected) "cabal-version: 2.0\nname: foo\n"
+        SB.writeFile (fromAbsFile expected) "cabal-version: 2.0\nname: foo\n"
         actual <- findCabalFile "foo" dir
         actual `shouldBe` expected
 
     it "prefers <pname>.cabal over a differently-named .cabal also in the directory" $
       withSystemTempDir "find-prefer-over-other" $ \dir -> do
         let expected = dir </> [relfile|foo.cabal|]
-        B.writeFile (fromAbsFile expected) "cabal-version: 2.0\nname: foo\n"
-        B.writeFile (fromAbsFile (dir </> [relfile|other.cabal|])) "cabal-version: 2.0\nname: other\n"
+        SB.writeFile (fromAbsFile expected) "cabal-version: 2.0\nname: foo\n"
+        SB.writeFile (fromAbsFile (dir </> [relfile|other.cabal|])) "cabal-version: 2.0\nname: other\n"
         actual <- findCabalFile "foo" dir
         actual `shouldBe` expected
 
     it "falls back to the single other .cabal file when <pname>.cabal is absent" $
       withSystemTempDir "find-fallback" $ \dir -> do
         let expected = dir </> [relfile|differently-named.cabal|]
-        B.writeFile (fromAbsFile expected) "cabal-version: 2.0\nname: x\n"
+        SB.writeFile (fromAbsFile expected) "cabal-version: 2.0\nname: x\n"
         actual <- findCabalFile "foo" dir
         actual `shouldBe` expected
 
@@ -199,8 +199,8 @@ spec = do
 
     it "throws AmbiguousCabalFile when <pname>.cabal is absent and multiple other .cabal files match" $
       withSystemTempDir "find-ambiguous" $ \dir -> do
-        B.writeFile (fromAbsFile (dir </> [relfile|a.cabal|])) "cabal-version: 2.0\nname: a\n"
-        B.writeFile (fromAbsFile (dir </> [relfile|b.cabal|])) "cabal-version: 2.0\nname: b\n"
+        SB.writeFile (fromAbsFile (dir </> [relfile|a.cabal|])) "cabal-version: 2.0\nname: a\n"
+        SB.writeFile (fromAbsFile (dir </> [relfile|b.cabal|])) "cabal-version: 2.0\nname: b\n"
         result <-
           (Exception.try :: IO (Path Abs File) -> IO (Either CabalFileLookupError (Path Abs File))) $
             findCabalFile "foo" dir

--- a/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/DiffRunSpec.hs
+++ b/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/DiffRunSpec.hs
@@ -2,12 +2,18 @@
 
 module Test.Syd.Mutation.Driver.DiffRunSpec (spec) where
 
+import qualified Data.Map.Strict as Map
 import Test.Syd
 import Test.Syd.Mutation.AugmentedManifest
-  ( MutationRunReport (..),
+  ( AugmentedMutationRecord (..),
+    MutationGroupReport (..),
+    MutationOutcome (..),
+    MutationRunReport (..),
+    SurvivedMutation (..),
   )
 import Test.Syd.Mutation.Driver.AssertScore (assertScoreResult)
 import Test.Syd.Mutation.Driver.DiffRun (renderDiffFinalSummary)
+import Test.Syd.Mutation.Runtime (MutationId (..))
 import Text.Colour (TerminalCapabilities (..), renderChunksText, unlinesChunks)
 
 -- | These golden files capture the final block of the diff runner's
@@ -65,7 +71,39 @@ spec = describe "renderDiffFinalSummary" $ do
           mutationRunReportTimedOut = 0,
           mutationRunReportUncovered = 0,
           mutationRunReportSkipped = 0,
-          mutationRunReportGroups = []
+          mutationRunReportGroups =
+            [ MutationGroupReport
+                { mutationGroupReportOutcomes =
+                    [OutcomeSurvived survivor]
+                }
+            ]
+        }
+
+    survivor =
+      SurvivedMutation
+        { survivedMutationRecord = survivorRecord,
+          survivedMutationLogFile = Nothing
+        }
+
+    survivorRecord =
+      AugmentedMutationRecord
+        { augmentedMutationRecordId =
+            MutationId ["Example.Lib", "BoolLit", "12", "8", "12"],
+          augmentedMutationRecordOperator = "BoolLit",
+          augmentedMutationRecordOriginal = "True",
+          augmentedMutationRecordReplacement = "False",
+          augmentedMutationRecordModule = "Example.Lib",
+          augmentedMutationRecordLine = 12,
+          augmentedMutationRecordEndLine = 12,
+          augmentedMutationRecordColStart = 8,
+          augmentedMutationRecordColEnd = 12,
+          augmentedMutationRecordSourceFile = Nothing,
+          augmentedMutationRecordSourceLines = [],
+          augmentedMutationRecordMutatedLines = [],
+          augmentedMutationRecordContextBefore = [],
+          augmentedMutationRecordContextAfter = [],
+          augmentedMutationRecordCoveringTests = Map.empty,
+          augmentedMutationRecordTimeoutMicros = 30000000
         }
 
     reportOneUncovered =
@@ -87,5 +125,5 @@ spec = describe "renderDiffFinalSummary" $ do
     -- terminal — not the colour-stripped version.
     renderColoured n report =
       let assertion = assertScoreResult True report
-          chunks = renderDiffFinalSummary n assertion txtPath jsonPath
+          chunks = renderDiffFinalSummary n assertion report txtPath jsonPath
        in renderChunksText With24BitColours (unlinesChunks chunks)

--- a/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/MutateSpec.hs
+++ b/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/MutateSpec.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module Test.Syd.Mutation.Driver.MutateSpec (spec) where
 
 import qualified Control.Exception as Exception
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
-import Path.IO (withSystemTempDir)
+import Path (fromAbsFile, parseAbsDir, relfile, (</>))
+import Path.IO (canonicalizePath, getPermissions, setOwnerExecutable, setPermissions, withSystemTempDir)
 import Test.Syd
 import Test.Syd.Mutation.AugmentedManifest
   ( AugmentedManifest (..),
@@ -13,10 +16,75 @@ import Test.Syd.Mutation.AugmentedManifest
     writeAugmentedManifestFile,
   )
 import Test.Syd.Mutation.Driver.Mutate (UnknownCoveringSuite (..), runMutationMode)
+import Test.Syd.Mutation.Driver.OptParse (SuiteConfig (..))
 import Test.Syd.Mutation.Runtime (MutationId (..))
+import Test.Syd.Mutation.TestId (TestId (..))
 
 spec :: Spec
-spec = describe "runMutationMode" $
+spec = describe "runMutationMode" $ do
+  it "runs each mutation child in its suite's resource directory" $
+    -- Regression test: the diff runner used to spawn mutation children
+    -- with no working directory, so they ran in the invocation dir instead
+    -- of the suite's resource dir that the coverage phase recorded covering
+    -- tests against — producing false survivors.  Here a stand-in suite exe
+    -- records its working directory; it must equal the configured resource
+    -- dir, not the test process's own working dir.
+    withSystemTempDir "mutate-resdir-manifest" $ \manifestDir ->
+      withSystemTempDir "mutate-resdir-out" $ \outDir ->
+        withSystemTempDir "mutate-resdir-res" $ \resourceDir -> do
+          let cwdFile = manifestDir </> [relfile|child-cwd.txt|]
+              exeFile = manifestDir </> [relfile|suite-exe|]
+          -- A suite exe that ignores the driver's args, records its working
+          -- directory, and exits 0 (so the mutation "survives").
+          writeFile
+            (fromAbsFile exeFile)
+            (unlines ["#!/bin/sh", "pwd -P > '" ++ fromAbsFile cwdFile ++ "'", "exit 0"])
+          perms <- getPermissions exeFile
+          setPermissions exeFile (setOwnerExecutable True perms)
+          let record =
+                AugmentedMutationRecord
+                  { augmentedMutationRecordId = MutationId ["M", "Op", "1", "1", "2"],
+                    augmentedMutationRecordOperator = "Op",
+                    augmentedMutationRecordOriginal = "+",
+                    augmentedMutationRecordReplacement = "-",
+                    augmentedMutationRecordModule = "M",
+                    augmentedMutationRecordLine = 1,
+                    augmentedMutationRecordEndLine = 1,
+                    augmentedMutationRecordColStart = 1,
+                    augmentedMutationRecordColEnd = 2,
+                    augmentedMutationRecordSourceFile = Nothing,
+                    augmentedMutationRecordSourceLines = [],
+                    augmentedMutationRecordMutatedLines = [],
+                    augmentedMutationRecordContextBefore = [],
+                    augmentedMutationRecordContextAfter = [],
+                    augmentedMutationRecordCoveringTests =
+                      Map.singleton "suite" [TestId (("t", 0) :| [])],
+                    augmentedMutationRecordTimeoutMicros = 30000000
+                  }
+          writeAugmentedManifestFile
+            manifestDir
+            (AugmentedManifest [AugmentedMutationGroup [record]])
+          _ <-
+            runMutationMode
+              False
+              False
+              manifestDir
+              outDir
+              Nothing
+              Nothing
+              ( Map.singleton
+                  "suite"
+                  SuiteConfig
+                    { suiteConfigExe = exeFile,
+                      suiteConfigResourceDir = Just resourceDir
+                    }
+              )
+          recorded <- readFile (fromAbsFile cwdFile)
+          recordedDir <- parseAbsDir (takeWhile (/= '\n') recorded)
+          canonRecorded <- canonicalizePath recordedDir
+          canonResource <- canonicalizePath resourceDir
+          canonRecorded `shouldBe` canonResource
+
   it "throws UnknownCoveringSuite when the manifest references a suite not in suiteExes" $
     withSystemTempDir "mutate-spec" $ \dir -> do
       let record =
@@ -43,7 +111,7 @@ spec = describe "runMutationMode" $
         (AugmentedManifest [AugmentedMutationGroup [record]])
       result <-
         Exception.try $
-          runMutationMode False dir dir Nothing Map.empty
+          runMutationMode False False dir dir Nothing Nothing Map.empty
       case result of
         Left (UnknownCoveringSuite name _) -> name `shouldBe` "absent-suite"
         Right _ -> expectationFailure "expected UnknownCoveringSuite to be thrown"

--- a/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/SuitePkgSpec.hs
+++ b/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/SuitePkgSpec.hs
@@ -5,7 +5,7 @@
 module Test.Syd.Mutation.Driver.SuitePkgSpec (spec) where
 
 import qualified Control.Exception as Exception
-import qualified Data.ByteString as B
+import qualified Data.ByteString as SB
 import qualified Data.Map.Strict as Map
 import Path
 import Path.IO (createDirIfMissing, withSystemTempDir)
@@ -22,8 +22,8 @@ spec = describe "walkSuitePkgs" $ do
           testDir = root </> [reldir|test|]
       createDirIfMissing True testDir
       createDirIfMissing True rd
-      B.writeFile (fromAbsFile (testDir </> [relfile|first-test|])) ""
-      B.writeFile (fromAbsFile (testDir </> [relfile|second-test|])) ""
+      SB.writeFile (fromAbsFile (testDir </> [relfile|first-test|])) ""
+      SB.writeFile (fromAbsFile (testDir </> [relfile|second-test|])) ""
       result <-
         walkSuitePkgs
           [ SuitePkgSpec
@@ -79,7 +79,7 @@ spec = describe "walkSuitePkgs" $ do
       createDirIfMissing True rootA -- no 'test' subdir
       createDirIfMissing True (rootB </> [reldir|test|])
       createDirIfMissing True rd
-      B.writeFile (fromAbsFile (rootB </> [relfile|test/only|])) ""
+      SB.writeFile (fromAbsFile (rootB </> [relfile|test/only|])) ""
       result <-
         walkSuitePkgs
           [ SuitePkgSpec "a" rootA rd,
@@ -95,8 +95,8 @@ spec = describe "walkSuitePkgs" $ do
       createDirIfMissing True (rootA </> [reldir|test|])
       createDirIfMissing True (rootB </> [reldir|test|])
       createDirIfMissing True rd
-      B.writeFile (fromAbsFile (rootA </> [relfile|test/clash|])) ""
-      B.writeFile (fromAbsFile (rootB </> [relfile|test/clash|])) ""
+      SB.writeFile (fromAbsFile (rootA </> [relfile|test/clash|])) ""
+      SB.writeFile (fromAbsFile (rootB </> [relfile|test/clash|])) ""
       result <-
         ( Exception.try ::
             IO (Map.Map a SuiteConfig) ->

--- a/sydtest-mutation-driver-gen/test_resources/diff-run/one-survivor-fail.golden
+++ b/sydtest-mutation-driver-gen/test_resources/diff-run/one-survivor-fail.golden
@@ -1,5 +1,11 @@
 
 [31mFAIL: [m[31m1[m surviving, [32m0[m uncovered out of 3 mutation(s).
 
+[31mSurviving mutations:[m
+
+BoolLit at Example/Lib.hs:12:8-12
+[31m    - True[m
+[32m    + False[m
+
 Full report:             /run/report.txt
 Machine-readable report: /run/report.json

--- a/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver.hs
+++ b/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver.hs
@@ -80,27 +80,23 @@ runDriver MutationDriverSettings {..} = do
         mutationDriverSettingFailFast
     )
     suitesAsc
-  -- Mutation phase: cd into the first suite's resource directory (in
-  -- Map.toAscList order, which is sorted by key), then run the mutation
-  -- parent.  The child suite-exe map is the same map of declared suites.
-  let firstSuiteResourceDir = case suitesAsc of
-        ((_, sc) : _) -> suiteConfigResourceDir sc
-        [] -> Nothing
-      suiteExesByName = Map.map suiteConfigExe suites
-  -- 'runMutationMode' prints the report to stdout and writes
-  -- report.json + report.txt + per-suite *.log files to the out dir.
-  -- It returns the run report; under --fail-fast we then exit non-zero
-  -- ourselves, preserving the historical behaviour of the @run@
-  -- subcommand (a downstream @assert-score@ step is the gate when
-  -- --fail-fast is off).
+  -- Mutation phase: 'runMutationMode' spawns each covering suite's mutation
+  -- child in that suite's own resource directory (it carries the full
+  -- 'SuiteConfig' map, not just the exes), so no parent-side 'cd' is needed
+  -- here.  It prints the report to stdout and writes report.json +
+  -- report.txt + per-suite *.log files to the out dir.  It returns the run
+  -- report; under --fail-fast we then exit non-zero ourselves, preserving
+  -- the historical behaviour of the @run@ subcommand (a downstream
+  -- @assert-score@ step is the gate when --fail-fast is off).
   report <-
-    withMaybeCurrentDir firstSuiteResourceDir $
-      runMutationMode
-        mutationDriverSettingFailFast
-        mutationDriverSettingAugmentedManifestDir
-        mutationDriverSettingOutDir
-        mutationDriverSettingChildMemLimit
-        suiteExesByName
+    runMutationMode
+      mutationDriverSettingFailFast
+      mutationDriverSettingDebug
+      mutationDriverSettingAugmentedManifestDir
+      mutationDriverSettingOutDir
+      mutationDriverSettingChildMemLimit
+      mutationDriverSettingMutationJobs
+      suites
   hFlush stdout
   when
     ( mutationDriverSettingFailFast

--- a/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/DiffRun.hs
+++ b/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/DiffRun.hs
@@ -27,7 +27,6 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8Lenient)
-import qualified Data.Text.IO as TIO
 import Path
 import Path.IO (forgivingAbsence, withSystemTempDir)
 import System.Exit (ExitCode (..), exitWith)
@@ -35,6 +34,11 @@ import System.IO (hFlush, stderr, stdout)
 import System.Process.Typed (proc, readProcessStdout_)
 import Test.Syd.Mutation.AugmentedManifest
   ( AugmentedManifest (..),
+    AugmentedMutationRecord (..),
+    MutationGroupReport (..),
+    MutationOutcome (..),
+    MutationRunReport (..),
+    SurvivedMutation (..),
     filterAugmentedManifestByIds,
     mergeAugmentedManifests,
     readAugmentedManifestFile,
@@ -50,11 +54,11 @@ import Test.Syd.Mutation.Driver.Mutate (runMutationMode)
 import Test.Syd.Mutation.Driver.OptParse
   ( DiffSettings (..),
     DiffSource (..),
-    SuiteConfig (..),
   )
 import Test.Syd.Mutation.Driver.SuitePkg (walkSuitePkgs)
 import Test.Syd.Mutation.TestId (TestId)
 import Test.Syd.Mutation.TestLocation (TestLocation (..), decodeTestLocations)
+import Test.Syd.MutationMode.Common (formatMutationLog)
 import Text.Colour
   ( Chunk,
     TerminalCapabilities (..),
@@ -64,6 +68,7 @@ import Text.Colour
     green,
     hPutChunksLocaleWith,
     putChunksLocaleWith,
+    red,
     unlinesChunks,
   )
 
@@ -117,13 +122,14 @@ runDiff DiffSettings {..} = do
   report <-
     withSystemTempDir "mutation-diff-augmented" $ \augDir -> do
       writeAugmentedManifestFile augDir filtered
-      let suiteExes = Map.map suiteConfigExe suites
       runMutationMode
         diffSettingFailFast
+        diffSettingDebug
         augDir
         diffSettingOutDir
         diffSettingChildMemLimit
-        suiteExes
+        diffSettingMutationJobs
+        suites
 
   -- 6. Final summary block: PASS/FAIL header + report paths, written to
   -- stdout so they're the last thing in the CI build log.  Hard-code
@@ -137,6 +143,7 @@ runDiff DiffSettings {..} = do
         renderDiffFinalSummary
           numSelected
           assertion
+          report
           (T.pack (fromAbsFile txtPath))
           (T.pack (fromAbsFile jsonPath))
   -- 'runMutationMode' already flushed stderr; flush again so any further
@@ -161,6 +168,14 @@ runDiff DiffSettings {..} = do
 -- no-op.  For a non-empty selection, the header comes from
 -- 'assertScoreResult'.
 --
+-- When the run produced survivors, their full per-mutation detail (the
+-- same diff blocks 'renderMutationRunReport' prints) is repeated here,
+-- between the header and the report paths.  The full report body printed
+-- earlier by 'runMutationMode' lists survivors before the uncovered and
+-- skipped sections, so in a long CI log the survivors scroll off the
+-- bottom; pinning a survivors-only block to the very end means the thing
+-- that failed the run is the last thing the log shows.
+--
 -- Pure so it can be golden-tested without spinning up a real run; the
 -- output is exactly the @stdout@ block the CI log ends with.
 renderDiffFinalSummary ::
@@ -169,23 +184,41 @@ renderDiffFinalSummary ::
   -- | Assertion result for the produced report.  Ignored when 0
   -- mutations were selected.
   AssertScoreResult ->
+  -- | The produced report, for the survivors-only detail block.
+  MutationRunReport ->
   -- | Path to @report.txt@ in the out dir.
   Text ->
   -- | Path to @report.json@ in the out dir.
   Text ->
   [[Chunk]]
-renderDiffFinalSummary numSelected assertion txtPath jsonPath =
+renderDiffFinalSummary numSelected assertion report txtPath jsonPath =
   [ [],
     header,
-    [],
-    [chunk "Full report:             ", chunk txtPath],
-    [chunk "Machine-readable report: ", chunk jsonPath]
+    []
   ]
+    ++ survivorsBlock
+    ++ [ [chunk "Full report:             ", chunk txtPath],
+         [chunk "Machine-readable report: ", chunk jsonPath]
+       ]
   where
     header
       | numSelected == 0 =
           [fore green (chunk "PASS: "), chunk "nothing to mutation-test in this diff."]
       | otherwise = assertScoreHeader assertion
+    survivors =
+      [ s
+      | g <- mutationRunReportGroups report,
+        OutcomeSurvived s <- mutationGroupReportOutcomes g
+      ]
+    survivorsBlock
+      | null survivors = []
+      | otherwise =
+          [[fore red (chunk "Surviving mutations:")]]
+            ++ concatMap renderSurvivor survivors
+            ++ [[]]
+    renderSurvivor s =
+      let rec = survivedMutationRecord s
+       in [] : formatMutationLog (augmentedMutationRecordId rec) rec
 
 -- | Render the one-line "N changed hunks; selected M mutations" progress
 -- message as coloured chunks, matching the rest of the driver's output.
@@ -212,8 +245,8 @@ renderDiffSelection numHunks numSource numTest numTotal =
 -- | Obtain the unified diff text from the configured source.
 obtainDiff :: DiffSource -> IO Text
 obtainDiff = \case
-  DiffSourceFile f -> TIO.readFile (fromAbsFile f)
-  DiffSourceStdin -> TIO.getContents
+  DiffSourceFile f -> decodeUtf8Lenient <$> SB.readFile (fromAbsFile f)
+  DiffSourceStdin -> decodeUtf8Lenient . LB.toStrict <$> LB.getContents
   DiffSourceGitMergeBase base -> gitMergeBaseDiff base
 
 -- | Compute @git diff <merge-base>@ where @<merge-base>@ is the merge-base of

--- a/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/DiffRun.hs
+++ b/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/DiffRun.hs
@@ -20,7 +20,7 @@ module Test.Syd.Mutation.Driver.DiffRun
   )
 where
 
-import qualified Data.ByteString as B
+import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -250,7 +250,7 @@ readTestLocations coverageDirs suiteName = do
   maps <-
     mapM
       ( \path -> do
-          mbs <- forgivingAbsence (B.readFile (fromAbsFile path))
+          mbs <- forgivingAbsence (SB.readFile (fromAbsFile path))
           case mbs of
             Nothing -> pure Map.empty
             Just bs -> case decodeTestLocations bs of

--- a/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/Mutate.hs
+++ b/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/Mutate.hs
@@ -35,7 +35,7 @@ import Path
 import Path.IO (copyFile, ignoringAbsence, withSystemTempDir)
 import System.Exit (ExitCode (..))
 import System.IO (BufferMode (..), IOMode (..), hFlush, hSetBuffering, stderr, withFile)
-import System.Process.Typed (proc, setStderr, setStdout, startProcess, stopProcess, useHandleOpen, waitExitCode)
+import System.Process.Typed (proc, setStderr, setStdout, setWorkingDir, startProcess, stopProcess, useHandleOpen, waitExitCode)
 import Test.Syd.Mutation.AugmentedManifest
   ( AugmentedManifest (..),
     AugmentedMutationGroup (..),
@@ -49,6 +49,7 @@ import Test.Syd.Mutation.AugmentedManifest
     readAugmentedManifestFile,
     writeMutationRunReport,
   )
+import Test.Syd.Mutation.Driver.OptParse (SuiteConfig (..))
 import Test.Syd.Mutation.Runtime (renderMutationId)
 import Test.Syd.MutationMode.Common
   ( MutationFailFast (..),
@@ -101,6 +102,14 @@ writeReportTxt renderedChunks outDir =
 runMutationMode ::
   -- | Whether to abort on the first surviving or uncovered mutation.
   Bool ->
+  -- | Debug mode.  A concise one-line progress message is printed for
+  -- every mutation regardless, so a long run shows steady activity; in
+  -- debug mode each of those lines is followed by the mutation's full
+  -- source diff.  Off by default because that per-mutation diff — for
+  -- the killed mutations that are the overwhelming majority of a healthy
+  -- run — floods the build log and buries the survivors; the final
+  -- report still lists every survivor in full.
+  Bool ->
   -- | Augmented-manifest directory.
   Path Abs Dir ->
   -- | Output directory: report.json, report.txt, and per-suite *.log
@@ -108,15 +117,27 @@ runMutationMode ::
   Path Abs Dir ->
   -- | Optional RTS heap cap to apply to each mutation child.
   Maybe String ->
-  -- | Map of suite name to exe path; used to find each covering suite's
-  -- exe when spawning a mutation child.
-  Map.Map Text (Path Abs File) ->
+  -- | Maximum number of mutation children to run concurrently.  'Nothing'
+  -- uses 'getNumCapabilities'.  Capping this matters for suites that spin up
+  -- a resource per test (e.g. a tmp-postgres): at full core-count
+  -- concurrency that resource flakes under contention, which surfaces as a
+  -- spuriously-failing test and therefore a /false kill/ — non-reproducible
+  -- and inconsistent with a lower-volume diff-scoped run.  Mirrors the
+  -- coverage phase's @--coverage-jobs@.
+  Maybe Word ->
+  -- | Map of suite name to its config (exe + resource dir).  The exe is
+  -- spawned for each covering suite; the resource dir becomes the child's
+  -- working directory, so a mutation child enumerates the same spec forest
+  -- and resolves the same relative resource paths that the coverage phase
+  -- did — without which the recorded covering-test ids may not match the
+  -- forest the child sees, producing false survivors.
+  Map.Map Text SuiteConfig ->
   IO MutationRunReport
-runMutationMode failFast augDir outDir childMemLimit suiteExes = do
+runMutationMode failFast debug augDir outDir childMemLimit mutationJobs suiteConfigs = do
   hSetBuffering stderr (BlockBuffering Nothing)
   AugmentedManifest groups <- readAugmentedManifestFile augDir
   -- Validate that every covering-suite name in the manifest is in
-  -- 'suiteExes' before any worker spawns.  An unknown name would otherwise
+  -- 'suiteConfigs' before any worker spawns.  An unknown name would otherwise
   -- surface as an 'ErrorCall' from inside a 'mapConcurrently' worker, which
   -- is harder to attribute.
   let referenced =
@@ -125,16 +146,18 @@ runMutationMode failFast augDir outDir childMemLimit suiteExes = do
           | AugmentedMutationGroup rs <- groups,
             r <- rs
           ]
-      missing = Map.difference referenced suiteExes
+      missing = Map.difference referenced suiteConfigs
   case Map.keys missing of
     [] -> pure ()
     (name : _) ->
       Exception.throwIO
         UnknownCoveringSuite
           { unknownCoveringSuiteName = name,
-            unknownCoveringSuiteDeclared = Map.keys suiteExes
+            unknownCoveringSuiteDeclared = Map.keys suiteConfigs
           }
-  n <- getNumCapabilities
+  n <- case mutationJobs of
+    Just j | j > 0 -> pure (fromIntegral j)
+    _ -> getNumCapabilities
   sem <- newQSem n
   -- Each group's per-mutation results, accumulated in source order so a
   -- partial report (after a global fail-fast abort) reflects the work
@@ -212,7 +235,7 @@ runMutationMode failFast augDir outDir childMemLimit suiteExes = do
     runOne sem record =
       bracket_ (waitQSem sem) (signalQSem sem) $ do
         let mid = augmentedMutationRecordId record
-        hPutChunksLocaleWith With8BitColours stderr (unlinesChunks (renderMutationProgressEvent (MutationProgressEvent record)))
+        hPutChunksLocaleWith With8BitColours stderr (unlinesChunks (renderMutationProgressEvent debug (MutationProgressEvent record)))
         -- Only run suites that have at least one covering test for this
         -- mutation.
         let coveringBySuite =
@@ -254,19 +277,20 @@ runMutationMode failFast augDir outDir childMemLimit suiteExes = do
         mTimedOut = listToMaybe [(micros, mLog) | SuiteTimedOut micros mLog <- NE.toList outcomes]
 
     runOneSuite record mid suiteName = do
-      exe <- case Map.lookup suiteName suiteExes of
-        Just e -> pure (fromAbsFile e)
+      (exe, mResourceDir) <- case Map.lookup suiteName suiteConfigs of
+        Just SuiteConfig {suiteConfigExe, suiteConfigResourceDir} ->
+          pure (fromAbsFile suiteConfigExe, suiteConfigResourceDir)
         Nothing ->
           -- Should be unreachable: 'runMutationMode' validates up-front
           -- that every covering-suite name in the manifest is in
-          -- 'suiteExes'.  If this fires, the manifest is being mutated
+          -- 'suiteConfigs'.  If this fires, the manifest is being mutated
           -- between that check and this lookup, or the validation has a
           -- bug — either way, throw an attributable exception rather
           -- than 'error'.
           Exception.throwIO
             UnknownCoveringSuite
               { unknownCoveringSuiteName = suiteName,
-                unknownCoveringSuiteDeclared = Map.keys suiteExes
+                unknownCoveringSuiteDeclared = Map.keys suiteConfigs
               }
       let rtsArgs = case childMemLimit of
             Nothing -> []
@@ -287,9 +311,14 @@ runMutationMode failFast augDir outDir childMemLimit suiteExes = do
           (outcomeRaw, elapsedMicros) <-
             withFile (fromAbsFile logPath) WriteMode $ \logHandle -> do
               let childProc =
-                    setStdout (useHandleOpen logHandle) $
-                      setStderr (useHandleOpen logHandle) $
-                        proc exe args
+                    -- Run the child in the suite's resource directory, so it
+                    -- enumerates the same spec forest (and resolves the same
+                    -- relative resource paths) the coverage phase recorded
+                    -- covering-test ids against.
+                    maybe id (setWorkingDir . fromAbsDir) mResourceDir $
+                      setStdout (useHandleOpen logHandle) $
+                        setStderr (useHandleOpen logHandle) $
+                          proc exe args
                   -- Per-mutation monotonic-clock budget computed by the
                   -- coverage phase.
                   timeoutMicros = augmentedMutationRecordTimeoutMicros record

--- a/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/Mutate.hs
+++ b/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/Mutate.hs
@@ -22,7 +22,7 @@ import Control.Concurrent.Async (mapConcurrently, race)
 import Control.Concurrent.STM (atomically, modifyTVar', newTVarIO, readTVarIO)
 import Control.Exception (bracket, bracket_)
 import qualified Control.Exception as Exception
-import qualified Data.ByteString as BS
+import qualified Data.ByteString as SB
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import Data.Maybe (listToMaybe)
@@ -85,7 +85,7 @@ writeReportTxt :: [[Chunk]] -> Path Abs Dir -> IO ()
 writeReportTxt renderedChunks outDir =
   let renderedText = renderChunksText With8BitColours (unlinesChunks renderedChunks)
       reportFile = outDir </> [relfile|report.txt|]
-   in BS.writeFile (fromAbsFile reportFile) (TE.encodeUtf8 renderedText)
+   in SB.writeFile (fromAbsFile reportFile) (TE.encodeUtf8 renderedText)
 
 -- | Parent process: read @manifest-augmented.json@ and spawn one child
 -- subprocess per mutation per suite that covers it.

--- a/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/OptParse.hs
+++ b/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/OptParse.hs
@@ -110,10 +110,16 @@ data MutationDriverSettings = MutationDriverSettings
     mutationDriverSettingSuitePkgs :: ![SuitePkgSpec],
     mutationDriverSettingChildMemLimit :: !(Maybe String),
     mutationDriverSettingCoverageJobs :: !(Maybe Word),
+    -- | Max mutation children to run concurrently ('Nothing' =
+    -- 'getNumCapabilities').
+    mutationDriverSettingMutationJobs :: !(Maybe Word),
     mutationDriverSettingCoverageRetry :: !Word,
     mutationDriverSettingAugmentedManifestDir :: !(Path Abs Dir),
     mutationDriverSettingOutDir :: !(Path Abs Dir),
-    mutationDriverSettingFailFast :: !Bool
+    mutationDriverSettingFailFast :: !Bool,
+    -- | Print each mutation's full source diff as it is tested (concise
+    -- one-line progress is always printed regardless).
+    mutationDriverSettingDebug :: !Bool
   }
   deriving (Show, Eq, Generic)
 
@@ -165,10 +171,16 @@ data DiffSettings = DiffSettings
     diffSettingCoverageDirs :: ![Path Abs Dir],
     -- | RTS heap cap for each mutation child.
     diffSettingChildMemLimit :: !(Maybe String),
+    -- | Max mutation children to run concurrently ('Nothing' =
+    -- 'getNumCapabilities').
+    diffSettingMutationJobs :: !(Maybe Word),
     -- | Output directory for report.json\/report.txt\/per-suite logs.
     diffSettingOutDir :: !(Path Abs Dir),
     -- | Whether to abort on the first surviving or uncovered mutation.
-    diffSettingFailFast :: !Bool
+    diffSettingFailFast :: !Bool,
+    -- | Print each mutation's full source diff as it is tested (concise
+    -- one-line progress is always printed regardless).
+    diffSettingDebug :: !Bool
   }
   deriving (Show, Eq, Generic)
 
@@ -215,6 +227,7 @@ mutationDriverSettingsParser = do
           long "coverage-jobs",
           metavar "INT"
         ]
+  mutationDriverSettingMutationJobs <- mutationJobsParser
   mutationDriverSettingCoverageRetry <-
     setting
       [ help "How many times to retry a failing coverage child before giving up",
@@ -242,6 +255,7 @@ mutationDriverSettingsParser = do
         long "fail-fast",
         value defaultFailFast
       ]
+  mutationDriverSettingDebug <- debugSwitch
   pure MutationDriverSettings {..}
 
 -- | CLI parser for the @coverage@ subcommand.  Shares the coverage-relevant
@@ -328,6 +342,7 @@ diffSettingsParser = do
           long "child-mem-limit",
           metavar "LIMIT"
         ]
+  diffSettingMutationJobs <- mutationJobsParser
   diffSettingOutDir <-
     directoryPathSetting
       [ help "Output directory: where the driver writes report.txt, report.json, and per-suite *.log files (required)",
@@ -340,7 +355,35 @@ diffSettingsParser = do
         long "fail-fast",
         value defaultFailFast
       ]
+  diffSettingDebug <- debugSwitch
   pure DiffSettings {..}
+
+-- | The @--mutation-jobs@ option, shared by the @run@ and @diff@
+-- subcommands: cap how many mutation children run concurrently.  Absent =
+-- 'getNumCapabilities'.  Capping avoids the false kills that DB-backed
+-- suites produce when their per-test resource (e.g. tmp-postgres) flakes
+-- under full core-count contention.
+mutationJobsParser :: Parser (Maybe Word)
+mutationJobsParser =
+  optional $
+    setting
+      [ help "Maximum number of mutation children to run concurrently (default: number of capabilities)",
+        reader auto,
+        option,
+        long "mutation-jobs",
+        metavar "INT"
+      ]
+
+-- | The @--debug@ switch, shared by the @run@ and @diff@ subcommands:
+-- additionally print each mutation's full source diff as it is tested.
+debugSwitch :: Parser Bool
+debugSwitch =
+  setting
+    [ help "Print each mutation's full source diff as it is tested (off by default; concise progress is always shown)",
+      switch True,
+      long "debug",
+      value False
+    ]
 
 -- | Parse the diff source.  Precedence: an explicit @--diff FILE@ wins, then
 -- @--diff-stdin@, otherwise the default git merge-base computation against

--- a/sydtest-mutation-plugin/CHANGELOG.md
+++ b/sydtest-mutation-plugin/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [0.3.0.0] - 2026-06-09
+
+### Added
+
+* Per-operator configuration under the `operators` config object:
+
+  ```yaml
+  operators:
+    ConstEmptyList:
+      skip-strings: true
+    Arith:
+      enable: false
+  ```
+
+  Every operator takes an `enable` toggle (`enable: false` disables it, the
+  same as listing it in `disabled-mutations`).  Each operator reads its own
+  remaining keys, exposed as an opaque `operatorConfigExtra :: Map Text Value`.
+  The `ConstEmptyList` operator interprets two such keys: `skip-strings`
+  (do not target `[Char]`/`String` expressions at all — keeps genuine `[a]`,
+  `a /= Char`, list mutations) and `skip-literal-strings` (skip only
+  syntactic string literals).
+
+### Changed
+
+* `InstrumentEnv` and `runInstrument` now carry the per-operator
+  configuration (`Map Text OperatorConfig`) rather than individual flags.
+* The `OptParse` settings expose `OperatorConfig`, `operatorsConfigDisabled`,
+  and `operatorExtraFlag`; the old `OperatorsConfig`/`ConstEmptyListConfig`
+  types are gone.
+
 ## [0.2.1.0] - 2026-06-08
 
 ### Fixed

--- a/sydtest-mutation-plugin/default.nix
+++ b/sydtest-mutation-plugin/default.nix
@@ -1,19 +1,20 @@
-{ mkDerivation, base, bytestring, containers, directory, filepath
-, ghc, ghc-boot, lib, mtl, opt-env-conf, opt-env-conf-test, path
-, path-io, safe-coloured-text, sydtest, sydtest-discover
-, sydtest-mutation-runtime, template-haskell, text
+{ mkDerivation, aeson, base, bytestring, containers, directory
+, filepath, ghc, ghc-boot, lib, mtl, opt-env-conf
+, opt-env-conf-test, path, path-io, safe-coloured-text, sydtest
+, sydtest-discover, sydtest-mutation-runtime, template-haskell
+, text
 }:
 mkDerivation {
   pname = "sydtest-mutation-plugin";
-  version = "0.2.1.0";
+  version = "0.3.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    base bytestring containers directory filepath ghc ghc-boot mtl
-    opt-env-conf path path-io safe-coloured-text
+    aeson base bytestring containers directory filepath ghc ghc-boot
+    mtl opt-env-conf path path-io safe-coloured-text
     sydtest-mutation-runtime template-haskell text
   ];
   testHaskellDepends = [
-    base containers ghc opt-env-conf-test path sydtest text
+    aeson base containers ghc opt-env-conf-test path sydtest text
   ];
   testToolDepends = [ sydtest-discover ];
   homepage = "https://github.com/NorfairKing/sydtest#readme";

--- a/sydtest-mutation-plugin/package.yaml
+++ b/sydtest-mutation-plugin/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest-mutation-plugin
-version: 0.2.1.0
+version: 0.3.0.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md
@@ -16,6 +16,7 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
+  - aeson
   - bytestring
   - containers
   - directory
@@ -41,6 +42,7 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
+    - aeson
     - containers
     - ghc
     - opt-env-conf-test

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin.hs
@@ -26,6 +26,7 @@ import Test.Syd.Mutation.Plugin.Instrument
 import Test.Syd.Mutation.Plugin.Operators (allOperators)
 import Test.Syd.Mutation.Plugin.OptParse
   ( Settings (..),
+    operatorsConfigDisabled,
     resolveSettings,
   )
 
@@ -230,11 +231,16 @@ mutationTypeCheckAction opts ms tcGblEnv = do
       settingDisabledMutations = disabledFromConfig,
       settingIgnore = ignore,
       settingSkipThSplices = skipThSplices,
+      settingOperators = operatorsConfig,
       settingDebug = debug,
       settingSkipInstrumentation = skipInstrumentation,
       settingManifestDir = manifestDir
     } <-
     liftIO $ resolveSettings opts
+  -- Operators turned off via @operators.<Name>.enable: false@ are disabled
+  -- exactly as if listed in @disabled-mutations@.  Operator-specific options
+  -- ride along in each operator's config entry and are read by the operator.
+  let disabledFromOperatorsConfig = operatorsConfigDisabled operatorsConfig
   if "Paths_" `isPrefixOf` mn || mn `elem` exceptions || skipInstrumentation
     then pure tcGblEnv
     else do
@@ -249,7 +255,7 @@ mutationTypeCheckAction opts ms tcGblEnv = do
           liftIO $ putStrLn $ "mutation: skipping " ++ mn ++ " (DisableMutations)"
           pure tcGblEnv
         else do
-          let disabledNames = disabledFromConfig ++ [n | DisableNamed n <- disabledFromModAnns]
+          let disabledNames = disabledFromConfig ++ disabledFromOperatorsConfig ++ [n | DisableNamed n <- disabledFromModAnns]
           liftIO $ putStrLn $ "mutation: instrumenting " ++ mn
           let mSrcPath = ml_hs_file (ms_location ms)
           spliceSpans <-
@@ -257,7 +263,7 @@ mutationTypeCheckAction opts ms tcGblEnv = do
               then liftIO $ Map.findWithDefault [] mn <$> readIORef spliceSpansMap
               else pure []
           (binds', groups) <-
-            runInstrument tcGblEnv allOperators annEnv disabledNames mSrcPath debug skipThSplices spliceSpans ignore $
+            runInstrument tcGblEnv allOperators annEnv disabledNames mSrcPath debug skipThSplices operatorsConfig spliceSpans ignore $
               instrumentModule (tcg_binds tcGblEnv)
           let totalMutations = sum [length rs | MutationGroup rs <- groups]
           liftIO $ do

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Instrument.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Instrument.hs
@@ -64,6 +64,7 @@ import Path
 import Path.IO (forgivingAbsence, resolveFile')
 import Test.Syd.Mutation.Manifest (MutationGroup (..), MutationRecord (..))
 import Test.Syd.Mutation.Plugin.Operator.Util (opOccName)
+import Test.Syd.Mutation.Plugin.OptParse (OperatorConfig)
 import Test.Syd.Mutation.Runtime (MutationId (..))
 
 -- ---------------------------------------------------------------------------
@@ -154,6 +155,10 @@ data InstrumentEnv = InstrumentEnv
     -- 'ExpandedThingTc' wrapper in the typechecked AST.  Enabled by
     -- @--skip-th-splices@.
     instrumentEnvSkipThSplices :: Bool,
+    -- | Per-operator configuration (keyed by operator name) from the
+    -- @operators@ config object.  Operators read their own entry's
+    -- 'operatorConfigExtra' to interpret their options.
+    instrumentEnvOperatorsConfig :: Map Text OperatorConfig,
     -- | Splice 'RealSrcSpan's collected from the parsed AST (one entry per
     -- @$(...)@, @[name|...|]@, or 'SpliceD').  Only populated when
     -- 'instrumentEnvSkipThSplices' is True; used by 'recordMutation' to drop
@@ -265,6 +270,8 @@ runInstrument ::
   Bool ->
   -- | Skip TH splices and quasi-quotes.
   Bool ->
+  -- | Per-operator configuration, keyed by operator name.
+  Map Text OperatorConfig ->
   -- | Splice spans collected at parse time, used to filter mutations.
   [RealSrcSpan] ->
   -- | Unqualified identifier names whose call expressions are ignored: no
@@ -273,7 +280,7 @@ runInstrument ::
   [String] ->
   InstrM a ->
   TcM (a, [MutationGroup])
-runInstrument tcGblEnv operators annEnv disabledMutations mSrcPath debug skipThSplices spliceSpans ignore action = do
+runInstrument tcGblEnv operators annEnv disabledMutations mSrcPath debug skipThSplices operatorsConfig spliceSpans ignore action = do
   let rdrEnv = tcg_rdr_env tcGblEnv
       modul = tcg_mod tcGblEnv
   ifMutId <- lookupRdrEnvId rdrEnv "ifMutation"
@@ -298,6 +305,7 @@ runInstrument tcGblEnv operators annEnv disabledMutations mSrcPath debug skipThS
         instrumentEnvSourceFile = mSrcFile,
         instrumentEnvDebug = debug,
         instrumentEnvSkipThSplices = skipThSplices,
+        instrumentEnvOperatorsConfig = operatorsConfig,
         instrumentEnvSpliceSpans = spliceSpans,
         instrumentEnvIgnore = ignore,
         instrumentEnvInGuard = False,

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ConstEmptyList.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ConstEmptyList.hs
@@ -4,11 +4,14 @@
 module Test.Syd.Mutation.Plugin.Operator.ConstEmptyList (theOperator) where
 
 import Control.Monad.Reader (asks)
+import qualified Data.Map as Map
 import qualified Data.Text as T
 import GHC
-import GHC.Builtin.Types (listTyCon)
+import GHC.Builtin.Types (charTyCon, listTyCon)
+import GHC.Core.Type (tyConAppTyCon_maybe)
 import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), OpAppCtx (..), SrcSpanDelta (..))
-import Test.Syd.Mutation.Plugin.Operator.Util (ConstFnMatch (..), arrowTy, mkConstLambda, prefixFormPreview, viewConstFnResult)
+import Test.Syd.Mutation.Plugin.Operator.Util (ConstFnMatch (..), arrowTy, mkConstLambda, prefixFormPreview, unwrapWrap, viewConstFnResult)
+import Test.Syd.Mutation.Plugin.OptParse (OperatorConfig (..), operatorExtraFlag)
 
 -- | Replace an expression whose type is @arg1 -> ... -> argN -> [a]@
 -- (with @N >= 0@) with the constant function returning @[]@.
@@ -34,9 +37,19 @@ action ::
 action le elTy ConstFnMatch {cfnArgTys, cfnResTy} = do
   opAppCtx <- asks instrumentEnvOpAppCtx
   appDepth <- asks instrumentEnvAppDepth
-  let arity = length cfnArgTys
+  -- This operator interprets its own config entry's extra keys.
+  opsConfig <- asks instrumentEnvOperatorsConfig
+  let extra = maybe Map.empty operatorConfigExtra (Map.lookup "ConstEmptyList" opsConfig)
+      skipStrings = operatorExtraFlag "skip-strings" extra
+      skipLiteralStrings = operatorExtraFlag "skip-literal-strings" extra
+      arity = length cfnArgTys
+      -- 'skip-strings' drops every @[Char]@-typed expression; the narrower
+      -- 'skip-literal-strings' drops only syntactic string literals.
+      skippedAsString =
+        (skipStrings && isCharElemTy elTy)
+          || (skipLiteralStrings && isCharElemTy elTy && isStringLiteralExpr le)
   -- See 'ConstNothing' for the dominance rule.
-  if arity >= 1 && appDepth >= arity
+  if (arity >= 1 && appDepth >= arity) || skippedAsString
     then pure []
     else
       let emptyExpr = noLocA (ExplicitList elTy [])
@@ -65,3 +78,24 @@ action le elTy ConstFnMatch {cfnArgTys, cfnResTy} = do
             [] -> "[]"
             _ -> "\\" ++ unwords (replicate arity "_") ++ " -> []"
        in pure [(wholeTy, mutated, origLabel, replLabel, delta)]
+
+-- | Whether the list element type is 'Char' (i.e. the list is a
+-- @[Char]@/'String').  Used to honour @skip-strings@.
+isCharElemTy :: Type -> Bool
+isCharElemTy ty = tyConAppTyCon_maybe ty == Just charTyCon
+
+-- | Whether the expression is (syntactically) a string literal.  Strips
+-- evidence/parens wrappers and recognises the @fromString \"...\"@ form
+-- that @OverloadedStrings@ produces.  Used to honour
+-- @skip-literal-strings@.
+isStringLiteralExpr :: LHsExpr GhcTc -> Bool
+isStringLiteralExpr = go . unLoc
+  where
+    go e = case unwrapWrap e of
+      HsLit _ HsString {} -> True
+      HsPar _ inner -> go (unLoc inner)
+      -- @OverloadedStrings@: @fromString "..."@.
+      HsApp _ _ arg -> case unwrapWrap (unLoc arg) of
+        HsLit _ HsString {} -> True
+        _ -> False
+      _ -> False

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/Util.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/Util.hs
@@ -12,6 +12,7 @@ module Test.Syd.Mutation.Plugin.Operator.Util
     mkConstLambda,
     arrowTy,
     prefixFormPreview,
+    unwrapWrap,
   )
 where
 

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/OptParse.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/OptParse.hs
@@ -1,17 +1,27 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Test.Syd.Mutation.Plugin.OptParse
   ( Settings (..),
+    OperatorConfig (..),
+    operatorsConfigDisabled,
+    operatorExtraFlag,
     defaultSettings,
     parseSettings,
     resolveSettings,
   )
 where
 
+import Data.Aeson (Object, Value (..))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.List.NonEmpty (NonEmpty)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics (Generic)
 import OptEnvConf
@@ -48,10 +58,68 @@ data Settings = Settings
     settingIgnore :: ![String],
     -- | Skip mutations inside TH splices and quasi-quotes.
     settingSkipThSplices :: !Bool,
+    -- | Per-operator configuration, keyed by operator name, read from the
+    -- @operators@ config object.
+    settingOperators :: !(Map Text OperatorConfig),
     -- | Print each mutation site as it is recorded.
     settingDebug :: !Bool
   }
   deriving (Show, Eq, Generic)
+
+-- | Configuration for a single mutation operator, read from one entry of
+-- the @operators@ config object:
+--
+-- > operators:
+-- >   ConstEmptyList:
+-- >     enable: true
+-- >     skip-strings: true
+-- >   Arith:
+-- >     enable: false
+--
+-- @enable@ is common to every operator; the remaining keys are an opaque
+-- 'operatorConfigExtra' blob that each operator interprets itself (e.g.
+-- @ConstEmptyList@ reads @skip-strings@).  An operator absent from the
+-- config behaves as @enable: true@ with no extra.
+data OperatorConfig = OperatorConfig
+  { -- | Whether the operator runs.  @enable: false@ disables it exactly as
+    -- if its name were in @disabled-mutations@.
+    operatorConfigEnable :: !Bool,
+    -- | Operator-specific config keys (everything under the operator other
+    -- than @enable@), interpreted by the operator.
+    operatorConfigExtra :: !(Map Text Value)
+  }
+  deriving (Show, Eq, Generic)
+
+-- | Names of operators that 'OperatorConfig' explicitly disables.
+operatorsConfigDisabled :: Map Text OperatorConfig -> [String]
+operatorsConfigDisabled m =
+  [T.unpack opName | (opName, cfg) <- Map.toList m, not (operatorConfigEnable cfg)]
+
+-- | Read a boolean flag from an operator's 'operatorConfigExtra', defaulting
+-- to 'False'.  A small helper for operators interpreting their own config.
+operatorExtraFlag :: Text -> Map Text Value -> Bool
+operatorExtraFlag k m = case Map.lookup k m of
+  Just (Bool b) -> b
+  _ -> False
+
+-- | Decode the raw @operators@ config object into a per-operator map.
+decodeOperatorsConfig :: Object -> Map Text OperatorConfig
+decodeOperatorsConfig obj =
+  Map.fromList
+    [(Key.toText k, decodeOperatorConfig v) | (k, v) <- KeyMap.toList obj]
+  where
+    decodeOperatorConfig :: Value -> OperatorConfig
+    decodeOperatorConfig = \case
+      Object o ->
+        OperatorConfig
+          { operatorConfigEnable = case KeyMap.lookup "enable" o of
+              Just (Bool b) -> b
+              _ -> True,
+            operatorConfigExtra =
+              Map.fromList
+                [(Key.toText k, val) | (k, val) <- KeyMap.toList o, k /= "enable"]
+          }
+      _ -> OperatorConfig {operatorConfigEnable = True, operatorConfigExtra = Map.empty}
 
 -- | The settings the plugin uses when no @--config=PATH@ is passed and
 -- no environment variables are set.  Equivalent to running the parser
@@ -65,6 +133,7 @@ defaultSettings =
       settingDisabledMutations = [],
       settingIgnore = [],
       settingSkipThSplices = True,
+      settingOperators = Map.empty,
       settingDebug = False
     }
 
@@ -158,6 +227,14 @@ parseSettings =
           conf "skip-th-splices",
           value True
         ]
+    settingOperators <-
+      maybe Map.empty decodeOperatorsConfig
+        <$> optional
+          ( setting
+              [ help "Per-operator config object: operators.<Name>.{enable, <operator-specific keys>}",
+                conf "operators"
+              ]
+          )
     settingDebug <-
       yesNoSwitch
         [ help "Print each mutation site as it is recorded",

--- a/sydtest-mutation-plugin/sydtest-mutation-plugin.cabal
+++ b/sydtest-mutation-plugin/sydtest-mutation-plugin.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest-mutation-plugin
-version:        0.2.1.0
+version:        0.3.0.0
 category:       Testing
 homepage:       https://github.com/NorfairKing/sydtest#readme
 bug-reports:    https://github.com/NorfairKing/sydtest/issues
@@ -48,7 +48,8 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.7 && <5
+      aeson
+    , base >=4.7 && <5
     , bytestring
     , containers
     , directory
@@ -78,7 +79,8 @@ test-suite sydtest-mutation-plugin-test
   build-tool-depends:
       sydtest-discover:sydtest-discover
   build-depends:
-      base >=4.7 && <5
+      aeson
+    , base >=4.7 && <5
     , containers
     , ghc
     , opt-env-conf-test

--- a/sydtest-mutation-plugin/test/Test/Syd/Mutation/Plugin/OptParseSpec.hs
+++ b/sydtest-mutation-plugin/test/Test/Syd/Mutation/Plugin/OptParseSpec.hs
@@ -3,6 +3,9 @@
 
 module Test.Syd.Mutation.Plugin.OptParseSpec (spec) where
 
+import qualified Data.Aeson as JSON
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Map as Map
 import OptEnvConf.Test
 import Path
 import Test.Syd
@@ -43,3 +46,37 @@ spec = describe "Settings parser" $ do
       [("MUTATION_PLUGIN_MANIFEST_DIR", "/tmp/foo/")]
       Nothing
       defaultSettings {settingManifestDir = Just dir}
+
+  it "reads per-operator enable and operator-specific extra from 'operators'" $ do
+    -- operators:
+    --   Arith: { enable: false }
+    --   ConstEmptyList: { skip-strings: true }
+    let operatorsObject =
+          KeyMap.fromList
+            [ ("Arith", JSON.Object (KeyMap.fromList [("enable", JSON.Bool False)])),
+              ("ConstEmptyList", JSON.Object (KeyMap.fromList [("skip-strings", JSON.Bool True)]))
+            ]
+        config = KeyMap.fromList [("operators", JSON.Object operatorsObject)]
+        expectedOperators =
+          Map.fromList
+            [ ("Arith", OperatorConfig {operatorConfigEnable = False, operatorConfigExtra = Map.empty}),
+              ( "ConstEmptyList",
+                OperatorConfig
+                  { operatorConfigEnable = True,
+                    operatorConfigExtra = Map.fromList [("skip-strings", JSON.Bool True)]
+                  }
+              )
+            ]
+    -- Test 'parseSettings' directly: 'settingsParser' wraps it in
+    -- 'withLocalYamlConfig', which loads config from a file rather than the
+    -- object supplied here.
+    parserTest
+      parseSettings
+      []
+      []
+      (Just config)
+      defaultSettings {settingOperators = expectedOperators}
+    -- And the consumed views: Arith disabled, ConstEmptyList skip-strings on.
+    operatorsConfigDisabled expectedOperators `shouldBe` ["Arith"]
+    operatorExtraFlag "skip-strings" (operatorConfigExtra (expectedOperators Map.! "ConstEmptyList"))
+      `shouldBe` True

--- a/sydtest-mutation-runtime/src/Test/Syd/Mutation/AugmentedManifest.hs
+++ b/sydtest-mutation-runtime/src/Test/Syd/Mutation/AugmentedManifest.hs
@@ -35,7 +35,7 @@ where
 import Autodocodec
 import Control.Exception (Exception, throwIO)
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as B
+import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
 import Data.GenValidity
 import Data.GenValidity.Map ()
@@ -187,7 +187,7 @@ instance Exception AugmentedManifestDecodeException
 
 -- | Read from @<dir>/manifest-augmented.json@.
 --
--- Reads strictly (via 'B.readFile' + 'Aeson.decodeStrict') so the file
+-- Reads strictly (via 'SB.readFile' + 'Aeson.decodeStrict') so the file
 -- handle is closed before this function returns.  This is a defensive
 -- measure: under heavy concurrency the original 'LB.readFile' +
 -- 'Aeson.decode' path was a suspected (but unproven) contributor to a
@@ -196,7 +196,7 @@ instance Exception AugmentedManifestDecodeException
 readAugmentedManifestFile :: Path Abs Dir -> IO AugmentedManifest
 readAugmentedManifestFile dir = do
   let path = dir </> augmentedManifestRelFile
-  result <- Aeson.decodeStrict <$> B.readFile (fromAbsFile path)
+  result <- Aeson.decodeStrict <$> SB.readFile (fromAbsFile path)
   case result of
     Nothing -> throwIO (AugmentedManifestDecodeException (fromAbsFile path))
     Just m -> pure m
@@ -496,7 +496,7 @@ instance Exception MutationRunReportDecodeException
 
 -- | Read @report.json@ from the given directory.
 --
--- Reads strictly (via 'B.readFile' + 'Aeson.decodeStrict') so the file
+-- Reads strictly (via 'SB.readFile' + 'Aeson.decodeStrict') so the file
 -- handle is closed before this function returns.  Throws
 -- 'MutationRunReportDecodeException' on a decode failure rather than
 -- silently producing a 'Maybe', so a caller that depends on the report
@@ -505,7 +505,7 @@ instance Exception MutationRunReportDecodeException
 readMutationRunReport :: Path Abs Dir -> IO MutationRunReport
 readMutationRunReport dir = do
   let path = dir </> mutationRunReportRelFile
-  result <- Aeson.decodeStrict <$> B.readFile (fromAbsFile path)
+  result <- Aeson.decodeStrict <$> SB.readFile (fromAbsFile path)
   case result of
     Nothing -> throwIO (MutationRunReportDecodeException (fromAbsFile path))
     Just m -> pure m

--- a/sydtest-mutation-runtime/src/Test/Syd/Mutation/Manifest.hs
+++ b/sydtest-mutation-runtime/src/Test/Syd/Mutation/Manifest.hs
@@ -18,7 +18,7 @@ where
 
 import Autodocodec
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as B
+import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
 import Data.GenValidity
 import Data.GenValidity.Containers ()
@@ -163,7 +163,7 @@ writeManifestFile dir moduleName manifest = do
 --
 -- Reads strictly so the file handle is closed before this function returns.
 readManifestFile :: Path Abs File -> IO (Either String MutationManifest)
-readManifestFile path = Aeson.eitherDecodeStrict <$> B.readFile (fromAbsFile path)
+readManifestFile path = Aeson.eitherDecodeStrict <$> SB.readFile (fromAbsFile path)
 
 -- | Read and concatenate all per-module manifests from a directory.
 -- Files that fail to parse are skipped with a warning to stderr.

--- a/sydtest-mutation-runtime/src/Test/Syd/Mutation/TestBaselineMap.hs
+++ b/sydtest-mutation-runtime/src/Test/Syd/Mutation/TestBaselineMap.hs
@@ -11,7 +11,7 @@ where
 
 import Autodocodec
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as B
+import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
 import Data.GenValidity
 import Data.GenValidity.Containers ()
@@ -59,7 +59,7 @@ writeTestBaselineMapFile :: FilePath -> TestBaselineMap -> IO ()
 writeTestBaselineMapFile path m =
   LB.writeFile path (encodeJSONViaCodec m)
 
--- | Read the baseline map strictly (via 'B.readFile' +
+-- | Read the baseline map strictly (via 'SB.readFile' +
 -- 'eitherDecodeJSONViaCodec') so the file handle is closed before this
 -- function returns.  Defensive against a suspected (but unproven) contributor
 -- to 'BlockedIndefinitelyOnMVar' loops at the coverage/mutation phase
@@ -67,4 +67,4 @@ writeTestBaselineMapFile path m =
 -- failure.
 readTestBaselineMapFile :: FilePath -> IO (Either String TestBaselineMap)
 readTestBaselineMapFile path =
-  eitherDecodeJSONViaCodec . LB.fromStrict <$> B.readFile path
+  eitherDecodeJSONViaCodec . LB.fromStrict <$> SB.readFile path

--- a/sydtest-mutation-runtime/src/Test/Syd/Mutation/TestCoverageMap.hs
+++ b/sydtest-mutation-runtime/src/Test/Syd/Mutation/TestCoverageMap.hs
@@ -12,7 +12,7 @@ where
 import Autodocodec
 import qualified Data.Aeson as Aeson
 import Data.Bifunctor (second)
-import qualified Data.ByteString as B
+import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
 import Data.GenValidity
 import Data.GenValidity.Containers ()
@@ -63,10 +63,10 @@ writeTestCoverageMapFile path m =
 -- | Read a 'TestCoverageMap' from the given file path.
 -- Returns the aeson error message on parse failure.
 --
--- Reads strictly (via 'B.readFile' + 'eitherDecodeJSONViaCodec') so the file
+-- Reads strictly (via 'SB.readFile' + 'eitherDecodeJSONViaCodec') so the file
 -- handle is closed before this function returns.  Defensive against a
 -- suspected (but unproven) contributor to 'BlockedIndefinitelyOnMVar'
 -- loops at the coverage/mutation phase boundary on large projects.
 readTestCoverageMapFile :: FilePath -> IO (Either String TestCoverageMap)
 readTestCoverageMapFile path =
-  eitherDecodeJSONViaCodec . LB.fromStrict <$> B.readFile path
+  eitherDecodeJSONViaCodec . LB.fromStrict <$> SB.readFile path

--- a/sydtest-mutation-runtime/src/Test/Syd/Mutation/TestLocation.hs
+++ b/sydtest-mutation-runtime/src/Test/Syd/Mutation/TestLocation.hs
@@ -11,7 +11,7 @@ where
 
 import Autodocodec
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as B
+import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
 import Data.GenValidity
 import Data.GenValidity.Path ()
@@ -53,5 +53,5 @@ encodeTestLocations = Aeson.encode
 
 -- | Decode a JSON array of 'TestLocation's from the bytes of a
 -- @\<suite\>.json@ listing.  Returns 'Nothing' on a decode failure.
-decodeTestLocations :: B.ByteString -> Maybe [TestLocation]
+decodeTestLocations :: SB.ByteString -> Maybe [TestLocation]
 decodeTestLocations = Aeson.decodeStrict

--- a/sydtest-mutation/test/Test/Syd/ManifestSpec.hs
+++ b/sydtest-mutation/test/Test/Syd/ManifestSpec.hs
@@ -4,7 +4,7 @@
 module Test.Syd.ManifestSpec (spec) where
 
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as B
+import qualified Data.ByteString as SB
 import Test.Syd
 import Test.Syd.Mutation.Manifest
 import Test.Syd.Validity
@@ -23,7 +23,7 @@ spec = do
 
   describe "MutationManifest forward compatibility" $
     it "decodes a manifest written before optional fields were added" $ do
-      bytes <- B.readFile "test_resources/legacy-mutation-manifest.json"
+      bytes <- SB.readFile "test_resources/legacy-mutation-manifest.json"
       case Aeson.eitherDecodeStrict bytes of
         Left err -> expectationFailure $ "failed to decode legacy manifest: " ++ err
         Right (MutationManifest groups) -> case groups of

--- a/sydtest-sqitch-postgres/src/Test/Syd/Sqitch/Postgresql.hs
+++ b/sydtest-sqitch-postgres/src/Test/Syd/Sqitch/Postgresql.hs
@@ -59,7 +59,7 @@ where
 
 import Control.Monad (forM_, unless)
 import Control.Monad.Logger (runNoLoggingT)
-import qualified Data.ByteString as ByteString
+import qualified Data.ByteString as SB
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -189,5 +189,5 @@ readDeployScript settings scriptName = do
   deployDir <- parseRelDir "deploy"
   fileRel <- parseRelFile (Text.unpack scriptName <> ".sql")
   Text.decodeUtf8Lenient
-    <$> ByteString.readFile
+    <$> SB.readFile
       (fromAbsFile (sqitchSettingsProjectDir settings </> deployDir </> fileRel))

--- a/sydtest-sqitch-postgres/src/Test/Syd/Sqitch/Postgresql/Plan.hs
+++ b/sydtest-sqitch-postgres/src/Test/Syd/Sqitch/Postgresql/Plan.hs
@@ -7,7 +7,7 @@ module Test.Syd.Sqitch.Postgresql.Plan
   )
 where
 
-import qualified Data.ByteString as ByteString
+import qualified Data.ByteString as SB
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -70,7 +70,7 @@ readSqitchPlan ::
   Path Abs File ->
   IO [PlanStep]
 readSqitchPlan mGrandfatherTag path = do
-  contents <- Text.decodeUtf8Lenient <$> ByteString.readFile (fromAbsFile path)
+  contents <- Text.decodeUtf8Lenient <$> SB.readFile (fromAbsFile path)
   let allLines = Text.lines contents
       -- When there is no grandfather tag, no change is grandfathered;
       -- this is modelled by starting "past the tag" immediately.

--- a/sydtest/CHANGELOG.md
+++ b/sydtest/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.26.0.0] - 2026-06-09
+
+### Changed
+
+* `renderMutationProgressEvent` now takes a `Bool` (verbose) first argument.
+  The mutation runner prints a concise one-line progress message per
+  mutation by default and the full source diff of each mutation only when
+  the new `--debug` driver flag is set, so a long run no longer floods the
+  log with the diffs of killed mutations.
+
 ## [0.25.0.1] - 2026-06-04
 
 ### Changed

--- a/sydtest/default.nix
+++ b/sydtest/default.nix
@@ -7,7 +7,7 @@
 }:
 mkDerivation {
   pname = "sydtest";
-  version = "0.25.0.1";
+  version = "0.26.0.0";
   src = ./.;
   libraryHaskellDepends = [
     async autodocodec base bytestring containers deepseq dlist

--- a/sydtest/package.yaml
+++ b/sydtest/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest
-version: 0.25.0.1
+version: 0.26.0.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest/src/Test/Syd/MutationMode/Common.hs
+++ b/sydtest/src/Test/Syd/MutationMode/Common.hs
@@ -386,12 +386,20 @@ renderMutationRunReport
           [chunk "  2. Disable it: same annotations and config keys as for survivors above."]
         ]
 
-renderMutationProgressEvent :: MutationProgressEvent -> [[Chunk]]
-renderMutationProgressEvent (MutationProgressEvent rec) =
+-- | Render the per-mutation progress line emitted as each mutation is
+-- tested.  The first argument is whether to be verbose: in concise mode
+-- (the default) this is the single locating line @Testing mutation
+-- \<operator\> at \<file\>:\<line\>:\<cols\>@, so a long run still shows
+-- steady progress without flooding the log; in verbose\/debug mode the
+-- full source diff of the mutation follows — the same block the report
+-- prints for a survivor.
+renderMutationProgressEvent :: Bool -> MutationProgressEvent -> [[Chunk]]
+renderMutationProgressEvent verbose (MutationProgressEvent rec) =
   let logLines = formatMutationLog (augmentedMutationRecordId rec) rec
-   in case logLines of
+      withPrefix = case logLines of
         [] -> [[chunk "Testing mutation"]]
         (firstLine : rest) -> (chunk "Testing mutation " : firstLine) : rest
+   in if verbose then withPrefix else take 1 withPrefix
 
 -- | Progress event for the coverage phase.
 data CoverageProgressEvent

--- a/sydtest/sydtest.cabal
+++ b/sydtest/sydtest.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest
-version:        0.25.0.1
+version:        0.26.0.0
 synopsis:       A modern testing framework for Haskell with good defaults and advanced testing features.
 description:    A modern testing framework for Haskell with good defaults and advanced testing features. Sydtest aims to make the common easy and the hard possible. See https://github.com/NorfairKing/sydtest#readme for more information.
 category:       Testing


### PR DESCRIPTION
Diff-scoped mutation testing fixes, a per-operator plugin config, and a
qualifier cleanup. Split into four reviewable commits; base is the current
`development` tip.

## Commits

1. **Use `SB` as the qualifier for `Data.ByteString`** — mechanical rename
   (was `B` in the driver/runtime, `BS` in `Mutate`), leaving lazy
   `Data.ByteString.Lazy` as `LB`.

2. **Mutation driver: diff-runner accuracy, reporting, concurrency cap, debug**
   - **CWD fix (the real bug):** the diff-scoped runner now runs each mutation
     child in its suite's resource directory (per-child `setWorkingDir`,
     race-safe under `mapConcurrently`), matching the coverage phase and the
     full run. Previously the recorded covering `TestId`s didn't match the
     forest the child enumerated → false survivors. Also fixes the full run,
     which ran every suite's children from only the *first* suite's resource dir.
   - **Surviving-mutations report** repeated at the very end of stdout, so they
     aren't scrolled off in long CI logs.
   - **Lenient UTF-8 decoding** of the diff (`obtainDiff`), matching the git
     path, so a non-ASCII diff doesn't crash under a sandbox C locale.
   - **Concise per-mutation progress** by default; `--debug` adds the full diff.
   - **`--mutation-jobs`** caps mutation-child concurrency (mirrors
     `--coverage-jobs`; defaults to `coverageJobs`). DB-backed suites flake
     under full core-count contention, producing non-reproducible false kills.

3. **Mutation plugin: per-operator config** — a generic `operators` config
   object:
   ```yaml
   operators:
     ConstEmptyList:
       skip-strings: true
     Arith:
       enable: false
   ```
   `settingOperators :: Map Text OperatorConfig`; each `OperatorConfig` has an
   `enable` toggle (`enable: false` ≡ listing it in `disabled-mutations`) and an
   opaque `operatorConfigExtra :: Map Text Value` that each operator interprets
   itself. `ConstEmptyList` reads `skip-strings` (skip `[Char]`/`String`
   expressions, keeping genuine `[a]` list mutations) and `skip-literal-strings`.
   Defaults keep every operator enabled and the options off, so existing
   behaviour is unchanged.

4. **Bump `sydtest` to 0.26.0.0** for the breaking
   `renderMutationProgressEvent` signature change. (`sydtest-mutation-plugin`
   → 0.3.0.0 is in commit 3; driver/runtime stay `0.0.0.0`.)

## Validation

- `nix flake check` passes (release, weeder, `mutation-sydtest-mutation-example`,
  pre-commit).
- The downstream nix-ci `.#mutation` gate passes against this branch:
  `killed=2519, survived=0, uncovered=0`.
- New regression tests: each mutation child runs in its suite's resource dir
  (`MutateSpec`); the survivors report block (`DiffRunSpec` golden); per-operator
  `enable`/`extra` parsing (`OptParseSpec`).

## Note on commit granularity

The driver commit (2) bundles five improvements because they're coupled through
`runMutationMode`'s parameter list (it gained `debug`, `mutationJobs`, and the
`suiteConfigs` CWD change together) — splitting them further would mean
re-threading that signature across several non-compiling intermediate commits.
Happy to do that if you'd prefer it for review.
