### PR TITLE
Mutation: add SwitchFunctionArguments operator

### DIFF
--- a/nix/mutation.yaml
+++ b/nix/mutation.yaml
@@ -14,3 +14,12 @@ debug: true
 ignore:
   - mark
   - markM
+
+# Exercises 'SwitchFunctionArguments' suppression: 'majorityOf5' (in
+# Example.ConstFnLib) is symmetric in its arguments, so swapping any two
+# produces an equivalent, unkillable mutant.  Listing it here skips the swap
+# at every call to it.
+operators:
+  SwitchFunctionArguments:
+    skip-calls-to:
+      - majorityOf5

--- a/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/DiffRunSpec.hs
+++ b/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/DiffRunSpec.hs
@@ -103,7 +103,9 @@ spec = describe "renderDiffFinalSummary" $ do
           augmentedMutationRecordContextBefore = [],
           augmentedMutationRecordContextAfter = [],
           augmentedMutationRecordCoveringTests = Map.empty,
-          augmentedMutationRecordTimeoutMicros = 30000000
+          augmentedMutationRecordTimeoutMicros = 30000000,
+          augmentedMutationRecordBinding = Nothing,
+          augmentedMutationRecordMitigation = Nothing
         }
 
     reportOneUncovered =

--- a/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/DiffSpec.hs
+++ b/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/DiffSpec.hs
@@ -47,7 +47,9 @@ mkRecord idParts mSrc (line, endLine) covering =
       augmentedMutationRecordContextBefore = [],
       augmentedMutationRecordContextAfter = [],
       augmentedMutationRecordCoveringTests = covering,
-      augmentedMutationRecordTimeoutMicros = 30000000
+      augmentedMutationRecordTimeoutMicros = 30000000,
+      augmentedMutationRecordBinding = Nothing,
+      augmentedMutationRecordMitigation = Nothing
     }
 
 tid :: Text -> TestId

--- a/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/MutateSpec.hs
+++ b/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/MutateSpec.hs
@@ -59,7 +59,9 @@ spec = describe "runMutationMode" $ do
                     augmentedMutationRecordContextAfter = [],
                     augmentedMutationRecordCoveringTests =
                       Map.singleton "suite" [TestId (("t", 0) :| [])],
-                    augmentedMutationRecordTimeoutMicros = 30000000
+                    augmentedMutationRecordTimeoutMicros = 30000000,
+                    augmentedMutationRecordBinding = Nothing,
+                    augmentedMutationRecordMitigation = Nothing
                   }
           writeAugmentedManifestFile
             manifestDir
@@ -104,7 +106,9 @@ spec = describe "runMutationMode" $ do
                 augmentedMutationRecordContextBefore = [],
                 augmentedMutationRecordContextAfter = [],
                 augmentedMutationRecordCoveringTests = Map.singleton "absent-suite" [],
-                augmentedMutationRecordTimeoutMicros = 30000000
+                augmentedMutationRecordTimeoutMicros = 30000000,
+                augmentedMutationRecordBinding = Nothing,
+                augmentedMutationRecordMitigation = Nothing
               }
       writeAugmentedManifestFile
         dir

--- a/sydtest-mutation-driver-gen/test_resources/diff-run/one-survivor-fail.golden
+++ b/sydtest-mutation-driver-gen/test_resources/diff-run/one-survivor-fail.golden
@@ -6,6 +6,7 @@
 BoolLit at Example/Lib.hs:12:8-12
 [31m    - True[m
 [32m    + False[m
+  disable: add [33mBoolLit[m to disabled-mutations in the plugin config
 
 Full report:             /run/report.txt
 Machine-readable report: /run/report.json

--- a/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/DiffRun.hs
+++ b/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/DiffRun.hs
@@ -58,7 +58,7 @@ import Test.Syd.Mutation.Driver.OptParse
 import Test.Syd.Mutation.Driver.SuitePkg (walkSuitePkgs)
 import Test.Syd.Mutation.TestId (TestId)
 import Test.Syd.Mutation.TestLocation (TestLocation (..), decodeTestLocations)
-import Test.Syd.MutationMode.Common (formatMutationLog)
+import Test.Syd.MutationMode.Common (formatMutationLog, survivorMitigationLines)
 import Text.Colour
   ( Chunk,
     TerminalCapabilities (..),
@@ -218,7 +218,8 @@ renderDiffFinalSummary numSelected assertion report txtPath jsonPath =
             ++ [[]]
     renderSurvivor s =
       let rec = survivedMutationRecord s
-       in [] : formatMutationLog (augmentedMutationRecordId rec) rec
+       in ([] : formatMutationLog (augmentedMutationRecordId rec) rec)
+            ++ survivorMitigationLines rec
 
 -- | Render the one-line "N changed hunks; selected M mutations" progress
 -- message as coloured chunks, matching the rest of the driver's output.

--- a/sydtest-mutation-example-gen/sydtest-mutation-example-gen.cabal
+++ b/sydtest-mutation-example-gen/sydtest-mutation-example-gen.cabal
@@ -46,6 +46,7 @@ test-suite sydtest-mutation-example-gen-test
       Example.LocalDisableLibSpec
       Example.LogicLibSpec
       Example.OtherwiseLibSpec
+      Example.SwitchArgsLibSpec
       Paths_sydtest_mutation_example_gen
   hs-source-dirs:
       test

--- a/sydtest-mutation-example-gen/test/Example/SwitchArgsLibSpec.hs
+++ b/sydtest-mutation-example-gen/test/Example/SwitchArgsLibSpec.hs
@@ -1,0 +1,28 @@
+module Example.SwitchArgsLibSpec (spec) where
+
+import Example.SwitchArgsLib
+import Test.Syd
+
+spec :: Spec
+spec = do
+  describe "divideThe" $
+    -- Asymmetric arguments: the swapped @div b a@ gives a different result,
+    -- which kills the SwitchFunctionArguments mutant.
+    it "divides the first argument by the second" $
+      divideThe 6 2 `shouldBe` 3
+
+  describe "parenDivide" $
+    -- The parenthesised @div a b@ must produce exactly one swap mutant, and
+    -- the asymmetric @div@ lets this test kill it.
+    it "divides the first argument by the second, then succeeds" $
+      parenDivide 6 2 `shouldBe` 4
+
+  describe "makeColour" $
+    -- Distinct components, so swapping any pair changes the result and kills
+    -- each of the three SwitchFunctionArguments mutants.
+    it "keeps the components in order" $
+      makeColour 1 2 3 `shouldBe` RGB 1 2 3
+
+  describe "greyscale" $
+    it "repeats the single component" $
+      greyscale 7 `shouldBe` RGB 7 7 7

--- a/sydtest-mutation-example/src/Example/ConstFnLib.hs
+++ b/sydtest-mutation-example/src/Example/ConstFnLib.hs
@@ -80,10 +80,12 @@ majorityOf5 a b c d e =
 --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
 --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
 --
--- 'SwitchFunctionArguments' is disabled here: 'majorityOf5' is symmetric in
--- its arguments, so swapping any two of them yields an equivalent mutant that
--- no test can kill.  See 'Example.SwitchArgsLib' for the operator's killable
+-- 'SwitchFunctionArguments' would also fire on @majorityOf5 a b c d e@, but
+-- 'majorityOf5' is symmetric in its arguments, so swapping any two yields an
+-- equivalent mutant that no test can kill.  Rather than annotate the call
+-- site, @majorityOf5@ is listed under the operator's @skip-calls-to@ key in
+-- the mutation config (see @nix/mutation.yaml@), which suppresses the swap at
+-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
 -- behaviour.
-{-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
 majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d e

--- a/sydtest-mutation-example/src/Example/ConstFnLib.hs
+++ b/sydtest-mutation-example/src/Example/ConstFnLib.hs
@@ -61,6 +61,8 @@ implies a b = not a || b
 --
 --   * 'ConstBool' arity 2 produces @(\\_ _ -> True)@ and
 --     @(\\_ _ -> False)@ mutants.
+--   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments
+--     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.
 impliesPair :: (Bool, Bool) -> Bool
 impliesPair (a, b) = implies a b
 
@@ -77,5 +79,11 @@ majorityOf5 a b c d e =
 --   * 'ConstBool' arity 5 produces @(\\_ _ _ _ _ -> True)@ and
 --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
 --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+--
+-- 'SwitchFunctionArguments' is disabled here: 'majorityOf5' is symmetric in
+-- its arguments, so swapping any two of them yields an equivalent mutant that
+-- no test can kill.  See 'Example.SwitchArgsLib' for the operator's killable
+-- behaviour.
+{-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
 majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d e

--- a/sydtest-mutation-example/src/Example/SwitchArgsLib.hs
+++ b/sydtest-mutation-example/src/Example/SwitchArgsLib.hs
@@ -1,0 +1,35 @@
+module Example.SwitchArgsLib
+  ( divideThe,
+    parenDivide,
+    RGB (..),
+    makeColour,
+    greyscale,
+  )
+where
+
+-- | Integer division.  Both arguments are 'Int', so
+-- 'SwitchFunctionArguments' produces one mutant that swaps them: @div b a@
+-- instead of @div a b@.
+divideThe :: Int -> Int -> Int
+divideThe a b = div a b
+
+-- | A parenthesised application: the parentheses around @div a b@ are
+-- required for precedence, so GHC keeps an 'HsPar' node around it.  The swap
+-- mutation must be produced exactly once -- not once for the parenthesis node
+-- and once for the inner application.
+parenDivide :: Int -> Int -> Int
+parenDivide a b = succ (div a b)
+
+-- | A colour built from three 'Int' components.
+data RGB = RGB Int Int Int
+  deriving (Eq, Show)
+
+-- | All three arguments are 'Int', so 'SwitchFunctionArguments' produces one
+-- mutant per pair: swapping (r, g), (r, b), and (g, b).
+makeColour :: Int -> Int -> Int -> RGB
+makeColour r g b = RGB r g b
+
+-- | The same constructor applied to three textually identical arguments.
+-- Every swap would be a no-op, so 'SwitchFunctionArguments' produces nothing.
+greyscale :: Int -> RGB
+greyscale v = RGB v v v

--- a/sydtest-mutation-example/sydtest-mutation-example.cabal
+++ b/sydtest-mutation-example/sydtest-mutation-example.cabal
@@ -34,6 +34,7 @@ library
       Example.LocalDisableLib
       Example.LogicLib
       Example.OtherwiseLib
+      Example.SwitchArgsLib
       Example.UntestedLib
   other-modules:
       Paths_sydtest_mutation_example

--- a/sydtest-mutation-example/test_resources/manifests/Example.BoolLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.BoolLib.json
@@ -1,6 +1,7 @@
 [
   [
     {
+      "binding": "negateWrapped",
       "col_end": 21,
       "col_start": 17,
       "context_after": [],
@@ -35,6 +36,7 @@
   ],
   [
     {
+      "binding": "negateWrapped",
       "col_end": 25,
       "col_start": 22,
       "context_after": [],
@@ -67,6 +69,7 @@
       ]
     },
     {
+      "binding": "negateWrapped",
       "col_end": 25,
       "col_start": 22,
       "context_after": [],
@@ -101,6 +104,7 @@
   ],
   [
     {
+      "binding": "negateWrapped",
       "col_end": 25,
       "col_start": 17,
       "context_after": [],
@@ -135,6 +139,7 @@
   ],
   [
     {
+      "binding": "wrapFalse",
       "col_end": 23,
       "col_start": 18,
       "context_after": [
@@ -173,6 +178,7 @@
   ],
   [
     {
+      "binding": "wrapFalse",
       "col_end": 23,
       "col_start": 13,
       "context_after": [
@@ -211,6 +217,7 @@
   ],
   [
     {
+      "binding": "wrapTrue",
       "col_end": 21,
       "col_start": 17,
       "context_after": [
@@ -249,6 +256,7 @@
   ],
   [
     {
+      "binding": "wrapTrue",
       "col_end": 21,
       "col_start": 12,
       "context_after": [

--- a/sydtest-mutation-example/test_resources/manifests/Example.CaseLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.CaseLib.json
@@ -1,6 +1,7 @@
 [
   [
     {
+      "binding": "describeList",
       "col_end": 26,
       "col_start": 24,
       "context_after": [
@@ -39,6 +40,7 @@
   ],
   [
     {
+      "binding": "describeList",
       "col_end": 16,
       "col_start": 9,
       "context_after": [
@@ -76,6 +78,7 @@
   ],
   [
     {
+      "binding": "describeList",
       "col_end": 21,
       "col_start": 10,
       "context_after": [
@@ -112,6 +115,7 @@
   ],
   [
     {
+      "binding": "describeList",
       "col_end": 16,
       "col_start": 8,
       "context_after": [],
@@ -146,6 +150,7 @@
   ],
   [
     {
+      "binding": "describeList",
       "col_end": 16,
       "col_start": 19,
       "context_after": [],
@@ -183,6 +188,7 @@
   ],
   [
     {
+      "binding": "describeList",
       "col_end": 16,
       "col_start": 19,
       "context_after": [],
@@ -220,6 +226,7 @@
       ]
     },
     {
+      "binding": "describeList",
       "col_end": 16,
       "col_start": 19,
       "context_after": [],

--- a/sydtest-mutation-example/test_resources/manifests/Example.ConstFnLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.ConstFnLib.json
@@ -13,17 +13,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "26",
         "28",
         "\\_ -> True",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter (\\_ -> True) [a, b, c, d, e]) in n >= 3"
@@ -49,17 +49,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "26",
         "28",
         "\\_ -> False",
         "2"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter (\\_ -> False) [a, b, c, d, e]) in n >= 3"
@@ -87,17 +87,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "30",
         "31",
         "True",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [True, b, c, d, e]) in n >= 3"
@@ -123,17 +123,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "30",
         "31",
         "False",
         "2"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [False, b, c, d, e]) in n >= 3"
@@ -161,17 +161,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "71",
+        "73",
         "30",
         "31",
         "not (e)",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [not (a), b, c, d, e]) in n >= 3"
@@ -199,17 +199,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "33",
         "34",
         "True",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, True, c, d, e]) in n >= 3"
@@ -235,17 +235,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "33",
         "34",
         "False",
         "2"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, False, c, d, e]) in n >= 3"
@@ -273,17 +273,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "71",
+        "73",
         "33",
         "34",
         "not (e)",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, not (b), c, d, e]) in n >= 3"
@@ -311,17 +311,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "36",
         "37",
         "True",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, True, d, e]) in n >= 3"
@@ -347,17 +347,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "36",
         "37",
         "False",
         "2"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, False, d, e]) in n >= 3"
@@ -385,17 +385,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "71",
+        "73",
         "36",
         "37",
         "not (e)",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, not (c), d, e]) in n >= 3"
@@ -423,17 +423,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "39",
         "40",
         "True",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, True, e]) in n >= 3"
@@ -459,17 +459,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "39",
         "40",
         "False",
         "2"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, False, e]) in n >= 3"
@@ -497,17 +497,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "71",
+        "73",
         "39",
         "40",
         "not (e)",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, not (d), e]) in n >= 3"
@@ -535,17 +535,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "42",
         "43",
         "True",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, True]) in n >= 3"
@@ -571,17 +571,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "42",
         "43",
         "False",
         "2"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, False]) in n >= 3"
@@ -609,17 +609,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "71",
+        "73",
         "42",
         "43",
         "not (e)",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, not (e)]) in n >= 3"
@@ -647,17 +647,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstEmptyList",
-        "71",
+        "73",
         "29",
         "44",
         "[]",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id []) in n >= 3"
@@ -685,17 +685,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ListLit",
-        "71",
+        "73",
         "29",
         "44",
         "0 elements",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [],
       "operator": "ListLit",
@@ -719,17 +719,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ListLit",
-        "71",
+        "73",
         "29",
         "44",
         "4 elements",
         "2"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [],
       "operator": "ListLit",
@@ -753,17 +753,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ListLit",
-        "71",
+        "73",
         "29",
         "44",
         "4 elements",
         "3"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [],
       "operator": "ListLit",
@@ -789,17 +789,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstEmptyList",
-        "71",
+        "73",
         "19",
         "44",
         "[]",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length ([]) in n >= 3"
@@ -827,17 +827,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstEmptyList",
-        "71",
+        "73",
         "18",
         "45",
         "[]",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length [] in n >= 3"
@@ -865,17 +865,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "IntLit",
-        "71",
+        "73",
         "54",
         "55",
         "0",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, e]) in n >= 0"
@@ -901,17 +901,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "IntLit",
-        "71",
+        "73",
         "54",
         "55",
         "1",
         "2"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, e]) in n >= 1"
@@ -937,17 +937,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "IntLit",
-        "71",
+        "73",
         "54",
         "55",
         "-3",
         "3"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, e]) in n >= -3"
@@ -975,17 +975,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "Cmp",
-        "71",
+        "73",
         "49",
         "55",
         "<",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, e]) in n < 3"
@@ -1011,17 +1011,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "Cmp",
-        "71",
+        "73",
         "49",
         "55",
         "<=",
         "2"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, e]) in n <= 3"
@@ -1047,17 +1047,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "Cmp",
-        "71",
+        "73",
         "49",
         "55",
         ">",
         "3"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, e]) in n > 3"
@@ -1085,17 +1085,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "49",
         "55",
         "True",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, e]) in True"
@@ -1121,17 +1121,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "49",
         "55",
         "False",
         "2"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, e]) in False"
@@ -1159,17 +1159,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "71",
+        "73",
         "49",
         "55",
         "not (e)",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  let n = length (filter id [a, b, c, d, e]) in not (n >= 3)"
@@ -1197,17 +1197,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "3",
         "55",
         "True",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  True"
@@ -1233,17 +1233,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "71",
+        "73",
         "3",
         "55",
         "False",
         "2"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  False"
@@ -1271,17 +1271,17 @@
         "majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool",
         "majorityOf5 a b c d e ="
       ],
-      "end_line": 71,
+      "end_line": 73,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "71",
+        "73",
         "3",
         "55",
         "not (e)",
         "1"
       ],
-      "line": 71,
+      "line": 73,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "  not (let n = length (filter id [a, b, c, d, e]) in n >= 3)"
@@ -1301,21 +1301,21 @@
       "col_start": 50,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "50",
         "51",
         "True",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 True b c d e"
@@ -1333,21 +1333,21 @@
       "col_start": 50,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "50",
         "51",
         "False",
         "2"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 False b c d e"
@@ -1367,21 +1367,21 @@
       "col_start": 50,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "81",
+        "89",
         "50",
         "51",
         "not (e)",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 not (a) b c d e"
@@ -1401,21 +1401,21 @@
       "col_start": 52,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "52",
         "53",
         "True",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a True c d e"
@@ -1433,21 +1433,21 @@
       "col_start": 52,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "52",
         "53",
         "False",
         "2"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a False c d e"
@@ -1467,21 +1467,21 @@
       "col_start": 52,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "81",
+        "89",
         "52",
         "53",
         "not (e)",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a not (b) c d e"
@@ -1501,21 +1501,21 @@
       "col_start": 54,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "54",
         "55",
         "True",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b True d e"
@@ -1533,21 +1533,21 @@
       "col_start": 54,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "54",
         "55",
         "False",
         "2"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b False d e"
@@ -1567,21 +1567,21 @@
       "col_start": 54,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "81",
+        "89",
         "54",
         "55",
         "not (e)",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b not (c) d e"
@@ -1601,21 +1601,21 @@
       "col_start": 56,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "56",
         "57",
         "True",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c True e"
@@ -1633,21 +1633,21 @@
       "col_start": 56,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "56",
         "57",
         "False",
         "2"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c False e"
@@ -1667,21 +1667,21 @@
       "col_start": 56,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "81",
+        "89",
         "56",
         "57",
         "not (e)",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c not (d) e"
@@ -1701,21 +1701,21 @@
       "col_start": 58,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "58",
         "59",
         "True",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d True"
@@ -1733,21 +1733,21 @@
       "col_start": 58,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "58",
         "59",
         "False",
         "2"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d False"
@@ -1767,21 +1767,21 @@
       "col_start": 58,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "81",
+        "89",
         "58",
         "59",
         "not (e)",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d not (e)"
@@ -1801,21 +1801,21 @@
       "col_start": 38,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "38",
         "59",
         "True",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = True"
@@ -1833,21 +1833,21 @@
       "col_start": 38,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "81",
+        "89",
         "38",
         "59",
         "False",
         "2"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = False"
@@ -1867,21 +1867,21 @@
       "col_start": 38,
       "context_after": [],
       "context_before": [
-        "--     @(\\\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses",
-        "--     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).",
+        "-- behaviour.",
+        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 81,
+      "end_line": 89,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "81",
+        "89",
         "38",
         "59",
         "not (e)",
         "1"
       ],
-      "line": 81,
+      "line": 89,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = not (majorityOf5 a b c d e)"
@@ -2391,21 +2391,21 @@
         "-- mutation produces a well-formed prefix-form preview."
       ],
       "context_before": [
-        "--   * 'ConstBool' arity 2 produces @(\\\\_ _ -> True)@ and",
-        "--     @(\\\\_ _ -> False)@ mutants.",
+        "--   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments",
+        "--     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.",
         "impliesPair :: (Bool, Bool) -> Bool"
       ],
-      "end_line": 65,
+      "end_line": 67,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "65",
+        "67",
         "30",
         "31",
         "True",
         "1"
       ],
-      "line": 65,
+      "line": 67,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "impliesPair (a, b) = implies True b"
@@ -2427,21 +2427,21 @@
         "-- mutation produces a well-formed prefix-form preview."
       ],
       "context_before": [
-        "--   * 'ConstBool' arity 2 produces @(\\\\_ _ -> True)@ and",
-        "--     @(\\\\_ _ -> False)@ mutants.",
+        "--   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments",
+        "--     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.",
         "impliesPair :: (Bool, Bool) -> Bool"
       ],
-      "end_line": 65,
+      "end_line": 67,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "65",
+        "67",
         "30",
         "31",
         "False",
         "2"
       ],
-      "line": 65,
+      "line": 67,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "impliesPair (a, b) = implies False b"
@@ -2465,21 +2465,21 @@
         "-- mutation produces a well-formed prefix-form preview."
       ],
       "context_before": [
-        "--   * 'ConstBool' arity 2 produces @(\\\\_ _ -> True)@ and",
-        "--     @(\\\\_ _ -> False)@ mutants.",
+        "--   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments",
+        "--     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.",
         "impliesPair :: (Bool, Bool) -> Bool"
       ],
-      "end_line": 65,
+      "end_line": 67,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "65",
+        "67",
         "30",
         "31",
         "not (e)",
         "1"
       ],
-      "line": 65,
+      "line": 67,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "impliesPair (a, b) = implies not (a) b"
@@ -2503,21 +2503,21 @@
         "-- mutation produces a well-formed prefix-form preview."
       ],
       "context_before": [
-        "--   * 'ConstBool' arity 2 produces @(\\\\_ _ -> True)@ and",
-        "--     @(\\\\_ _ -> False)@ mutants.",
+        "--   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments",
+        "--     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.",
         "impliesPair :: (Bool, Bool) -> Bool"
       ],
-      "end_line": 65,
+      "end_line": 67,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "65",
+        "67",
         "32",
         "33",
         "True",
         "1"
       ],
-      "line": 65,
+      "line": 67,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "impliesPair (a, b) = implies a True"
@@ -2539,21 +2539,21 @@
         "-- mutation produces a well-formed prefix-form preview."
       ],
       "context_before": [
-        "--   * 'ConstBool' arity 2 produces @(\\\\_ _ -> True)@ and",
-        "--     @(\\\\_ _ -> False)@ mutants.",
+        "--   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments",
+        "--     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.",
         "impliesPair :: (Bool, Bool) -> Bool"
       ],
-      "end_line": 65,
+      "end_line": 67,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "65",
+        "67",
         "32",
         "33",
         "False",
         "2"
       ],
-      "line": 65,
+      "line": 67,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "impliesPair (a, b) = implies a False"
@@ -2577,21 +2577,21 @@
         "-- mutation produces a well-formed prefix-form preview."
       ],
       "context_before": [
-        "--   * 'ConstBool' arity 2 produces @(\\\\_ _ -> True)@ and",
-        "--     @(\\\\_ _ -> False)@ mutants.",
+        "--   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments",
+        "--     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.",
         "impliesPair :: (Bool, Bool) -> Bool"
       ],
-      "end_line": 65,
+      "end_line": 67,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "65",
+        "67",
         "32",
         "33",
         "not (e)",
         "1"
       ],
-      "line": 65,
+      "line": 67,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "impliesPair (a, b) = implies a not (b)"
@@ -2615,21 +2615,21 @@
         "-- mutation produces a well-formed prefix-form preview."
       ],
       "context_before": [
-        "--   * 'ConstBool' arity 2 produces @(\\\\_ _ -> True)@ and",
-        "--     @(\\\\_ _ -> False)@ mutants.",
+        "--   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments",
+        "--     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.",
         "impliesPair :: (Bool, Bool) -> Bool"
       ],
-      "end_line": 65,
+      "end_line": 67,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "65",
+        "67",
         "22",
         "33",
         "True",
         "1"
       ],
-      "line": 65,
+      "line": 67,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "impliesPair (a, b) = True"
@@ -2651,21 +2651,21 @@
         "-- mutation produces a well-formed prefix-form preview."
       ],
       "context_before": [
-        "--   * 'ConstBool' arity 2 produces @(\\\\_ _ -> True)@ and",
-        "--     @(\\\\_ _ -> False)@ mutants.",
+        "--   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments",
+        "--     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.",
         "impliesPair :: (Bool, Bool) -> Bool"
       ],
-      "end_line": 65,
+      "end_line": 67,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "65",
+        "67",
         "22",
         "33",
         "False",
         "2"
       ],
-      "line": 65,
+      "line": 67,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "impliesPair (a, b) = False"
@@ -2689,21 +2689,21 @@
         "-- mutation produces a well-formed prefix-form preview."
       ],
       "context_before": [
-        "--   * 'ConstBool' arity 2 produces @(\\\\_ _ -> True)@ and",
-        "--     @(\\\\_ _ -> False)@ mutants.",
+        "--   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments",
+        "--     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.",
         "impliesPair :: (Bool, Bool) -> Bool"
       ],
-      "end_line": 65,
+      "end_line": 67,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "65",
+        "67",
         "22",
         "33",
         "not (e)",
         "1"
       ],
-      "line": 65,
+      "line": 67,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "impliesPair (a, b) = not (implies a b)"
@@ -2711,6 +2711,44 @@
       "operator": "Negate",
       "original": "e",
       "replacement": "not (e)",
+      "source_file": "src/Example/ConstFnLib.hs",
+      "source_lines": [
+        "impliesPair (a, b) = implies a b"
+      ]
+    }
+  ],
+  [
+    {
+      "col_end": 33,
+      "col_start": 22,
+      "context_after": [
+        "",
+        "-- | A 5-argument predicate.  Used to confirm the 'ConstBool' arity-5",
+        "-- mutation produces a well-formed prefix-form preview."
+      ],
+      "context_before": [
+        "--   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments",
+        "--     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.",
+        "impliesPair :: (Bool, Bool) -> Bool"
+      ],
+      "end_line": 67,
+      "id": [
+        "Example.ConstFnLib",
+        "SwitchFunctionArguments",
+        "67",
+        "22",
+        "33",
+        "b a",
+        "1"
+      ],
+      "line": 67,
+      "module": "Example.ConstFnLib",
+      "mutated_lines": [
+        "impliesPair (a, b) = implies b a"
+      ],
+      "operator": "SwitchFunctionArguments",
+      "original": "a b",
+      "replacement": "b a",
       "source_file": "src/Example/ConstFnLib.hs",
       "source_lines": [
         "impliesPair (a, b) = implies a b"

--- a/sydtest-mutation-example/test_resources/manifests/Example.ConstFnLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.ConstFnLib.json
@@ -1,6 +1,7 @@
 [
   [
     {
+      "binding": "majorityOf5",
       "col_end": 28,
       "col_start": 26,
       "context_after": [
@@ -37,6 +38,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 28,
       "col_start": 26,
       "context_after": [
@@ -75,6 +77,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 31,
       "col_start": 30,
       "context_after": [
@@ -111,6 +114,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 31,
       "col_start": 30,
       "context_after": [
@@ -149,6 +153,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 31,
       "col_start": 30,
       "context_after": [
@@ -187,6 +192,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 34,
       "col_start": 33,
       "context_after": [
@@ -223,6 +229,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 34,
       "col_start": 33,
       "context_after": [
@@ -261,6 +268,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 34,
       "col_start": 33,
       "context_after": [
@@ -299,6 +307,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 37,
       "col_start": 36,
       "context_after": [
@@ -335,6 +344,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 37,
       "col_start": 36,
       "context_after": [
@@ -373,6 +383,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 37,
       "col_start": 36,
       "context_after": [
@@ -411,6 +422,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 40,
       "col_start": 39,
       "context_after": [
@@ -447,6 +459,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 40,
       "col_start": 39,
       "context_after": [
@@ -485,6 +498,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 40,
       "col_start": 39,
       "context_after": [
@@ -523,6 +537,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 43,
       "col_start": 42,
       "context_after": [
@@ -559,6 +574,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 43,
       "col_start": 42,
       "context_after": [
@@ -597,6 +613,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 43,
       "col_start": 42,
       "context_after": [
@@ -635,6 +652,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 44,
       "col_start": 29,
       "context_after": [
@@ -673,6 +691,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 44,
       "col_start": 29,
       "context_after": [
@@ -707,6 +726,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 44,
       "col_start": 29,
       "context_after": [
@@ -741,6 +761,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 44,
       "col_start": 29,
       "context_after": [
@@ -777,6 +798,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 44,
       "col_start": 19,
       "context_after": [
@@ -815,6 +837,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 45,
       "col_start": 18,
       "context_after": [
@@ -853,6 +876,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 54,
       "context_after": [
@@ -889,6 +913,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 54,
       "context_after": [
@@ -925,6 +950,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 54,
       "context_after": [
@@ -963,6 +989,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 49,
       "context_after": [
@@ -999,6 +1026,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 49,
       "context_after": [
@@ -1035,6 +1063,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 49,
       "context_after": [
@@ -1073,6 +1102,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 49,
       "context_after": [
@@ -1109,6 +1139,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 49,
       "context_after": [
@@ -1147,6 +1178,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 49,
       "context_after": [
@@ -1185,6 +1217,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 3,
       "context_after": [
@@ -1221,6 +1254,7 @@
       ]
     },
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 3,
       "context_after": [
@@ -1259,6 +1293,7 @@
   ],
   [
     {
+      "binding": "majorityOf5",
       "col_end": 55,
       "col_start": 3,
       "context_after": [
@@ -1297,6 +1332,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 51,
       "col_start": 50,
       "context_after": [],
@@ -1329,6 +1365,7 @@
       ]
     },
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 51,
       "col_start": 50,
       "context_after": [],
@@ -1363,6 +1400,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 51,
       "col_start": 50,
       "context_after": [],
@@ -1397,6 +1435,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 53,
       "col_start": 52,
       "context_after": [],
@@ -1429,6 +1468,7 @@
       ]
     },
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 53,
       "col_start": 52,
       "context_after": [],
@@ -1463,6 +1503,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 53,
       "col_start": 52,
       "context_after": [],
@@ -1497,6 +1538,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 55,
       "col_start": 54,
       "context_after": [],
@@ -1529,6 +1571,7 @@
       ]
     },
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 55,
       "col_start": 54,
       "context_after": [],
@@ -1563,6 +1606,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 55,
       "col_start": 54,
       "context_after": [],
@@ -1597,6 +1641,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 57,
       "col_start": 56,
       "context_after": [],
@@ -1629,6 +1674,7 @@
       ]
     },
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 57,
       "col_start": 56,
       "context_after": [],
@@ -1663,6 +1709,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 57,
       "col_start": 56,
       "context_after": [],
@@ -1697,6 +1744,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 59,
       "col_start": 58,
       "context_after": [],
@@ -1729,6 +1777,7 @@
       ]
     },
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 59,
       "col_start": 58,
       "context_after": [],
@@ -1763,6 +1812,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 59,
       "col_start": 58,
       "context_after": [],
@@ -1797,6 +1847,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 59,
       "col_start": 38,
       "context_after": [],
@@ -1829,6 +1880,7 @@
       ]
     },
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 59,
       "col_start": 38,
       "context_after": [],
@@ -1863,6 +1915,7 @@
   ],
   [
     {
+      "binding": "majorityOf5Wrapper",
       "col_end": 59,
       "col_start": 38,
       "context_after": [],
@@ -1897,6 +1950,7 @@
   ],
   [
     {
+      "binding": "implies",
       "col_end": 20,
       "col_start": 19,
       "context_after": [
@@ -1933,6 +1987,7 @@
       ]
     },
     {
+      "binding": "implies",
       "col_end": 20,
       "col_start": 19,
       "context_after": [
@@ -1971,6 +2026,7 @@
   ],
   [
     {
+      "binding": "implies",
       "col_end": 20,
       "col_start": 19,
       "context_after": [
@@ -2009,6 +2065,7 @@
   ],
   [
     {
+      "binding": "implies",
       "col_end": 20,
       "col_start": 15,
       "context_after": [
@@ -2045,6 +2102,7 @@
       ]
     },
     {
+      "binding": "implies",
       "col_end": 20,
       "col_start": 15,
       "context_after": [
@@ -2083,6 +2141,7 @@
   ],
   [
     {
+      "binding": "implies",
       "col_end": 20,
       "col_start": 15,
       "context_after": [
@@ -2121,6 +2180,7 @@
   ],
   [
     {
+      "binding": "implies",
       "col_end": 25,
       "col_start": 24,
       "context_after": [
@@ -2157,6 +2217,7 @@
       ]
     },
     {
+      "binding": "implies",
       "col_end": 25,
       "col_start": 24,
       "context_after": [
@@ -2195,6 +2256,7 @@
   ],
   [
     {
+      "binding": "implies",
       "col_end": 25,
       "col_start": 24,
       "context_after": [
@@ -2233,6 +2295,7 @@
   ],
   [
     {
+      "binding": "implies",
       "col_end": 25,
       "col_start": 15,
       "context_after": [
@@ -2269,6 +2332,7 @@
       ]
     },
     {
+      "binding": "implies",
       "col_end": 25,
       "col_start": 15,
       "context_after": [
@@ -2307,6 +2371,7 @@
   ],
   [
     {
+      "binding": "implies",
       "col_end": 25,
       "col_start": 15,
       "context_after": [
@@ -2345,6 +2410,7 @@
   ],
   [
     {
+      "binding": "implies",
       "col_end": 25,
       "col_start": 15,
       "context_after": [
@@ -2383,6 +2449,7 @@
   ],
   [
     {
+      "binding": "impliesPair",
       "col_end": 31,
       "col_start": 30,
       "context_after": [
@@ -2419,6 +2486,7 @@
       ]
     },
     {
+      "binding": "impliesPair",
       "col_end": 31,
       "col_start": 30,
       "context_after": [
@@ -2457,6 +2525,7 @@
   ],
   [
     {
+      "binding": "impliesPair",
       "col_end": 31,
       "col_start": 30,
       "context_after": [
@@ -2495,6 +2564,7 @@
   ],
   [
     {
+      "binding": "impliesPair",
       "col_end": 33,
       "col_start": 32,
       "context_after": [
@@ -2531,6 +2601,7 @@
       ]
     },
     {
+      "binding": "impliesPair",
       "col_end": 33,
       "col_start": 32,
       "context_after": [
@@ -2569,6 +2640,7 @@
   ],
   [
     {
+      "binding": "impliesPair",
       "col_end": 33,
       "col_start": 32,
       "context_after": [
@@ -2607,6 +2679,7 @@
   ],
   [
     {
+      "binding": "impliesPair",
       "col_end": 33,
       "col_start": 22,
       "context_after": [
@@ -2643,6 +2716,7 @@
       ]
     },
     {
+      "binding": "impliesPair",
       "col_end": 33,
       "col_start": 22,
       "context_after": [
@@ -2681,6 +2755,7 @@
   ],
   [
     {
+      "binding": "impliesPair",
       "col_end": 33,
       "col_start": 22,
       "context_after": [
@@ -2719,6 +2794,7 @@
   ],
   [
     {
+      "binding": "impliesPair",
       "col_end": 33,
       "col_start": 22,
       "context_after": [
@@ -2742,6 +2818,7 @@
         "1"
       ],
       "line": 67,
+      "mitigation": "If `implies` is symmetric in these arguments this is an equivalent mutant that no test can kill; add `implies` to this operator's `skip-calls-to` config to suppress it.",
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "impliesPair (a, b) = implies b a"
@@ -2757,6 +2834,7 @@
   ],
   [
     {
+      "binding": "keepDigits",
       "col_end": 20,
       "col_start": 14,
       "context_after": [
@@ -2795,6 +2873,7 @@
   ],
   [
     {
+      "binding": "keepDigits",
       "col_end": 28,
       "col_start": 21,
       "context_after": [
@@ -2831,6 +2910,7 @@
       ]
     },
     {
+      "binding": "keepDigits",
       "col_end": 28,
       "col_start": 21,
       "context_after": [
@@ -2869,6 +2949,7 @@
   ],
   [
     {
+      "binding": "keepDigits",
       "col_end": 28,
       "col_start": 14,
       "context_after": [
@@ -2907,6 +2988,7 @@
   ],
   [
     {
+      "binding": "digitsOf",
       "col_end": 26,
       "col_start": 25,
       "context_after": [
@@ -2945,6 +3027,7 @@
   ],
   [
     {
+      "binding": "digitsOf",
       "col_end": 26,
       "col_start": 14,
       "context_after": [
@@ -2983,6 +3066,7 @@
   ],
   [
     {
+      "binding": "safeHead",
       "col_end": 26,
       "col_start": 20,
       "context_after": [
@@ -3021,6 +3105,7 @@
   ],
   [
     {
+      "binding": "firstChar",
       "col_end": 25,
       "col_start": 24,
       "context_after": [
@@ -3059,6 +3144,7 @@
   ],
   [
     {
+      "binding": "firstChar",
       "col_end": 25,
       "col_start": 15,
       "context_after": [

--- a/sydtest-mutation-example/test_resources/manifests/Example.ConstFnLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.ConstFnLib.json
@@ -1301,21 +1301,21 @@
       "col_start": 50,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "50",
         "51",
         "True",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 True b c d e"
@@ -1333,21 +1333,21 @@
       "col_start": 50,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "50",
         "51",
         "False",
         "2"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 False b c d e"
@@ -1367,21 +1367,21 @@
       "col_start": 50,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "89",
+        "91",
         "50",
         "51",
         "not (e)",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 not (a) b c d e"
@@ -1401,21 +1401,21 @@
       "col_start": 52,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "52",
         "53",
         "True",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a True c d e"
@@ -1433,21 +1433,21 @@
       "col_start": 52,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "52",
         "53",
         "False",
         "2"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a False c d e"
@@ -1467,21 +1467,21 @@
       "col_start": 52,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "89",
+        "91",
         "52",
         "53",
         "not (e)",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a not (b) c d e"
@@ -1501,21 +1501,21 @@
       "col_start": 54,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "54",
         "55",
         "True",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b True d e"
@@ -1533,21 +1533,21 @@
       "col_start": 54,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "54",
         "55",
         "False",
         "2"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b False d e"
@@ -1567,21 +1567,21 @@
       "col_start": 54,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "89",
+        "91",
         "54",
         "55",
         "not (e)",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b not (c) d e"
@@ -1601,21 +1601,21 @@
       "col_start": 56,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "56",
         "57",
         "True",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c True e"
@@ -1633,21 +1633,21 @@
       "col_start": 56,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "56",
         "57",
         "False",
         "2"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c False e"
@@ -1667,21 +1667,21 @@
       "col_start": 56,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "89",
+        "91",
         "56",
         "57",
         "not (e)",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c not (d) e"
@@ -1701,21 +1701,21 @@
       "col_start": 58,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "58",
         "59",
         "True",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d True"
@@ -1733,21 +1733,21 @@
       "col_start": 58,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "58",
         "59",
         "False",
         "2"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d False"
@@ -1767,21 +1767,21 @@
       "col_start": 58,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "89",
+        "91",
         "58",
         "59",
         "not (e)",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d not (e)"
@@ -1801,21 +1801,21 @@
       "col_start": 38,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "38",
         "59",
         "True",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = True"
@@ -1833,21 +1833,21 @@
       "col_start": 38,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "ConstBool",
-        "89",
+        "91",
         "38",
         "59",
         "False",
         "2"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = False"
@@ -1867,21 +1867,21 @@
       "col_start": 38,
       "context_after": [],
       "context_before": [
+        "-- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable",
         "-- behaviour.",
-        "{-# ANN majorityOf5Wrapper (\"DisableMutation: SwitchFunctionArguments\" :: String) #-}",
         "majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool"
       ],
-      "end_line": 89,
+      "end_line": 91,
       "id": [
         "Example.ConstFnLib",
         "Negate",
-        "89",
+        "91",
         "38",
         "59",
         "not (e)",
         "1"
       ],
-      "line": 89,
+      "line": 91,
       "module": "Example.ConstFnLib",
       "mutated_lines": [
         "majorityOf5Wrapper (a, b, c, d, e) = not (majorityOf5 a b c d e)"

--- a/sydtest-mutation-example/test_resources/manifests/Example.ConstFnLib.txt
+++ b/sydtest-mutation-example/test_resources/manifests/Example.ConstFnLib.txt
@@ -383,146 +383,146 @@ Negate at src/Example/ConstFnLib.hs:73:3-55 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:89:50-51 #1
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:50-51 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 [m[1;91ma[m[31m b c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 [m[1;92mT[m[1;92mr[m[1;92mu[m[1;92me[m[32m b c d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:89:50-51 #2
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:50-51 #2
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 [m[31ma[m[31m b c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 [m[1;92mF[m[32ma[m[1;92ml[m[1;92ms[m[1;92me[m[32m b c d e[m
 
-Negate at src/Example/ConstFnLib.hs:89:50-51 #1
-[36m@@ -86,4 +86,4 @@[m
+Negate at src/Example/ConstFnLib.hs:91:50-51 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5[m[31m [m[31ma[m[31m b c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32ma[m[1;92m)[m[32m b c d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:89:52-53 #1
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:52-53 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a [m[1;91mb[m[31m c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a [m[1;92mT[m[1;92mr[m[1;92mu[m[1;92me[m[32m c d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:89:52-53 #2
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:52-53 #2
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a [m[1;91mb[m[31m c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a [m[1;92mF[m[1;92ma[m[1;92mls[m[1;92me[m[32m c d e[m
 
-Negate at src/Example/ConstFnLib.hs:89:52-53 #1
-[36m@@ -86,4 +86,4 @@[m
+Negate at src/Example/ConstFnLib.hs:91:52-53 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a[m[31m [m[31mb[m[31m c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32mb[m[1;92m)[m[32m c d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:89:54-55 #1
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:54-55 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b [m[1;91mc[m[31m d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b [m[1;92mT[m[1;92mr[m[1;92mu[m[1;92me[m[32m d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:89:54-55 #2
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:54-55 #2
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b [m[1;91mc[m[31m d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b [m[1;92mF[m[1;92ma[m[1;92mls[m[1;92me[m[32m d e[m
 
-Negate at src/Example/ConstFnLib.hs:89:54-55 #1
-[36m@@ -86,4 +86,4 @@[m
+Negate at src/Example/ConstFnLib.hs:91:54-55 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b[m[31m [m[31mc[m[31m d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32mc[m[1;92m)[m[32m d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:89:56-57 #1
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:56-57 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c [m[1;91md[m[31m e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c [m[1;92mT[m[1;92mr[m[1;92mu[m[1;92me[m[32m e[m
 
-ConstBool at src/Example/ConstFnLib.hs:89:56-57 #2
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:56-57 #2
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c [m[1;91md[m[31m e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c [m[1;92mF[m[1;92ma[m[1;92mls[m[1;92me[m[32m e[m
 
-Negate at src/Example/ConstFnLib.hs:89:56-57 #1
-[36m@@ -86,4 +86,4 @@[m
+Negate at src/Example/ConstFnLib.hs:91:56-57 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c[m[31m [m[31md[m[31m e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32md[m[1;92m)[m[32m e[m
 
-ConstBool at src/Example/ConstFnLib.hs:89:58-59 #1
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:58-59 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d [m[31me[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d [m[1;92mT[m[1;92mr[m[1;92mu[m[32me[m
 
-ConstBool at src/Example/ConstFnLib.hs:89:58-59 #2
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:58-59 #2
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d [m[31me[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d [m[1;92mF[m[1;92ma[m[1;92ml[m[1;92ms[m[32me[m
 
-Negate at src/Example/ConstFnLib.hs:89:58-59 #1
-[36m@@ -86,4 +86,4 @@[m
+Negate at src/Example/ConstFnLib.hs:91:58-59 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d[m[31m [m[31me[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32me[m[1;92m)[m
 
-ConstBool at src/Example/ConstFnLib.hs:89:38-59 #1
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:38-59 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = [m[1;91mm[m[1;91ma[m[1;91mj[m[1;91mo[m[31mr[m[1;91mityOf[m[1;91m5 a b[m[1;91m c [m[1;91md[m[41m [m[31me[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = [m[1;92mT[m[32mr[m[1;92mu[m[32me[m
 
-ConstBool at src/Example/ConstFnLib.hs:89:38-59 #2
-[36m@@ -86,4 +86,4 @@[m
+ConstBool at src/Example/ConstFnLib.hs:91:38-59 #2
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) =[m[41m [m[1;91mm[m[1;91ma[m[1;91mjor[m[1;91mityOf[m[1;91m5[m[31m [m[31ma[m[41m [m[1;91mb[m[1;91m c [m[1;91md[m[41m [m[31me[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) =[m[32m [m[1;92mF[m[32ma[m[1;92mls[m[32me[m
 
-Negate at src/Example/ConstFnLib.hs:89:38-59 #1
-[36m@@ -86,4 +86,4 @@[m
+Negate at src/Example/ConstFnLib.hs:91:38-59 #1
+[36m@@ -88,4 +88,4 @@[m
+ -- every call to it.  See 'Example.SwitchArgsLib' for the operator's killable
  -- behaviour.
- {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) =[m[31m [m[31mmajorityOf5 a b c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) =[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32mmajorityOf5 a b c d e[m[1;92m)[m

--- a/sydtest-mutation-example/test_resources/manifests/Example.ConstFnLib.txt
+++ b/sydtest-mutation-example/test_resources/manifests/Example.ConstFnLib.txt
@@ -1,8 +1,8 @@
 [36m# Example.ConstFnLib[m
-84 mutations in 56 groups
+85 mutations in 57 groups
 
-ConstBool at src/Example/ConstFnLib.hs:71:26-28 #1
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:26-28 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -12,8 +12,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:26-28 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:26-28 #2
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:26-28 #2
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -23,8 +23,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:26-28 #2
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:30-31 #1
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:30-31 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -34,8 +34,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:30-31 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:30-31 #2
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:30-31 #2
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -45,8 +45,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:30-31 #2
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-Negate at src/Example/ConstFnLib.hs:71:30-31 #1
-[36m@@ -68,7 +68,7 @@[m
+Negate at src/Example/ConstFnLib.hs:73:30-31 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -56,8 +56,8 @@ Negate at src/Example/ConstFnLib.hs:71:30-31 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:33-34 #1
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:33-34 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -67,8 +67,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:33-34 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:33-34 #2
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:33-34 #2
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -78,8 +78,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:33-34 #2
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-Negate at src/Example/ConstFnLib.hs:71:33-34 #1
-[36m@@ -68,7 +68,7 @@[m
+Negate at src/Example/ConstFnLib.hs:73:33-34 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -89,8 +89,8 @@ Negate at src/Example/ConstFnLib.hs:71:33-34 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:36-37 #1
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:36-37 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -100,8 +100,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:36-37 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:36-37 #2
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:36-37 #2
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -111,8 +111,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:36-37 #2
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-Negate at src/Example/ConstFnLib.hs:71:36-37 #1
-[36m@@ -68,7 +68,7 @@[m
+Negate at src/Example/ConstFnLib.hs:73:36-37 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -122,8 +122,8 @@ Negate at src/Example/ConstFnLib.hs:71:36-37 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:39-40 #1
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:39-40 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -133,8 +133,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:39-40 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:39-40 #2
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:39-40 #2
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -144,8 +144,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:39-40 #2
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-Negate at src/Example/ConstFnLib.hs:71:39-40 #1
-[36m@@ -68,7 +68,7 @@[m
+Negate at src/Example/ConstFnLib.hs:73:39-40 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -155,8 +155,8 @@ Negate at src/Example/ConstFnLib.hs:71:39-40 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:42-43 #1
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:42-43 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -166,8 +166,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:42-43 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:42-43 #2
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:42-43 #2
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -177,8 +177,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:42-43 #2
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-Negate at src/Example/ConstFnLib.hs:71:42-43 #1
-[36m@@ -68,7 +68,7 @@[m
+Negate at src/Example/ConstFnLib.hs:73:42-43 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -188,8 +188,8 @@ Negate at src/Example/ConstFnLib.hs:71:42-43 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstEmptyList at src/Example/ConstFnLib.hs:71:29-44 #1
-[36m@@ -68,7 +68,7 @@[m
+ConstEmptyList at src/Example/ConstFnLib.hs:73:29-44 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -199,8 +199,8 @@ ConstEmptyList at src/Example/ConstFnLib.hs:71:29-44 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ListLit at src/Example/ConstFnLib.hs:71:29-44 #1
-[36m@@ -68,7 +68,6 @@[m
+ListLit at src/Example/ConstFnLib.hs:73:29-44 #1
+[36m@@ -70,7 +70,6 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -209,8 +209,8 @@ ListLit at src/Example/ConstFnLib.hs:71:29-44 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ListLit at src/Example/ConstFnLib.hs:71:29-44 #2
-[36m@@ -68,7 +68,6 @@[m
+ListLit at src/Example/ConstFnLib.hs:73:29-44 #2
+[36m@@ -70,7 +70,6 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -219,8 +219,8 @@ ListLit at src/Example/ConstFnLib.hs:71:29-44 #2
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ListLit at src/Example/ConstFnLib.hs:71:29-44 #3
-[36m@@ -68,7 +68,6 @@[m
+ListLit at src/Example/ConstFnLib.hs:73:29-44 #3
+[36m@@ -70,7 +70,6 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -229,8 +229,8 @@ ListLit at src/Example/ConstFnLib.hs:71:29-44 #3
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstEmptyList at src/Example/ConstFnLib.hs:71:19-44 #1
-[36m@@ -68,7 +68,7 @@[m
+ConstEmptyList at src/Example/ConstFnLib.hs:73:19-44 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -240,8 +240,8 @@ ConstEmptyList at src/Example/ConstFnLib.hs:71:19-44 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstEmptyList at src/Example/ConstFnLib.hs:71:18-45 #1
-[36m@@ -68,7 +68,7 @@[m
+ConstEmptyList at src/Example/ConstFnLib.hs:73:18-45 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -251,8 +251,8 @@ ConstEmptyList at src/Example/ConstFnLib.hs:71:18-45 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-IntLit at src/Example/ConstFnLib.hs:71:54-55 #1
-[36m@@ -68,7 +68,7 @@[m
+IntLit at src/Example/ConstFnLib.hs:73:54-55 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -262,8 +262,8 @@ IntLit at src/Example/ConstFnLib.hs:71:54-55 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-IntLit at src/Example/ConstFnLib.hs:71:54-55 #2
-[36m@@ -68,7 +68,7 @@[m
+IntLit at src/Example/ConstFnLib.hs:73:54-55 #2
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -273,8 +273,8 @@ IntLit at src/Example/ConstFnLib.hs:71:54-55 #2
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-IntLit at src/Example/ConstFnLib.hs:71:54-55 #3
-[36m@@ -68,7 +68,7 @@[m
+IntLit at src/Example/ConstFnLib.hs:73:54-55 #3
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -284,8 +284,8 @@ IntLit at src/Example/ConstFnLib.hs:71:54-55 #3
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-Cmp at src/Example/ConstFnLib.hs:71:49-55 #1
-[36m@@ -68,7 +68,7 @@[m
+Cmp at src/Example/ConstFnLib.hs:73:49-55 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -295,8 +295,8 @@ Cmp at src/Example/ConstFnLib.hs:71:49-55 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-Cmp at src/Example/ConstFnLib.hs:71:49-55 #2
-[36m@@ -68,7 +68,7 @@[m
+Cmp at src/Example/ConstFnLib.hs:73:49-55 #2
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -306,8 +306,8 @@ Cmp at src/Example/ConstFnLib.hs:71:49-55 #2
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-Cmp at src/Example/ConstFnLib.hs:71:49-55 #3
-[36m@@ -68,7 +68,7 @@[m
+Cmp at src/Example/ConstFnLib.hs:73:49-55 #3
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -317,8 +317,8 @@ Cmp at src/Example/ConstFnLib.hs:71:49-55 #3
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:49-55 #1
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:49-55 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -328,8 +328,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:49-55 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:49-55 #2
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:49-55 #2
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -339,8 +339,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:49-55 #2
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-Negate at src/Example/ConstFnLib.hs:71:49-55 #1
-[36m@@ -68,7 +68,7 @@[m
+Negate at src/Example/ConstFnLib.hs:73:49-55 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -350,8 +350,8 @@ Negate at src/Example/ConstFnLib.hs:71:49-55 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:3-55 #1
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:3-55 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -361,8 +361,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:3-55 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:71:3-55 #2
-[36m@@ -68,7 +68,7 @@[m
+ConstBool at src/Example/ConstFnLib.hs:73:3-55 #2
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -372,8 +372,8 @@ ConstBool at src/Example/ConstFnLib.hs:71:3-55 #2
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-Negate at src/Example/ConstFnLib.hs:71:3-55 #1
-[36m@@ -68,7 +68,7 @@[m
+Negate at src/Example/ConstFnLib.hs:73:3-55 #1
+[36m@@ -70,7 +70,7 @@[m
  -- mutation produces a well-formed prefix-form preview.
  majorityOf5 :: Bool -> Bool -> Bool -> Bool -> Bool -> Bool
  majorityOf5 a b c d e =
@@ -383,146 +383,146 @@ Negate at src/Example/ConstFnLib.hs:71:3-55 #1
  -- | A wrapper that references 'majorityOf5' as a bare arity-5 name.
  --
 
-ConstBool at src/Example/ConstFnLib.hs:81:50-51 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:50-51 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 [m[1;91ma[m[31m b c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 [m[1;92mT[m[1;92mr[m[1;92mu[m[1;92me[m[32m b c d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:81:50-51 #2
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:50-51 #2
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 [m[31ma[m[31m b c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 [m[1;92mF[m[32ma[m[1;92ml[m[1;92ms[m[1;92me[m[32m b c d e[m
 
-Negate at src/Example/ConstFnLib.hs:81:50-51 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+Negate at src/Example/ConstFnLib.hs:89:50-51 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5[m[31m [m[31ma[m[31m b c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32ma[m[1;92m)[m[32m b c d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:81:52-53 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:52-53 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a [m[1;91mb[m[31m c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a [m[1;92mT[m[1;92mr[m[1;92mu[m[1;92me[m[32m c d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:81:52-53 #2
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:52-53 #2
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a [m[1;91mb[m[31m c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a [m[1;92mF[m[1;92ma[m[1;92mls[m[1;92me[m[32m c d e[m
 
-Negate at src/Example/ConstFnLib.hs:81:52-53 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+Negate at src/Example/ConstFnLib.hs:89:52-53 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a[m[31m [m[31mb[m[31m c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32mb[m[1;92m)[m[32m c d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:81:54-55 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:54-55 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b [m[1;91mc[m[31m d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b [m[1;92mT[m[1;92mr[m[1;92mu[m[1;92me[m[32m d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:81:54-55 #2
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:54-55 #2
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b [m[1;91mc[m[31m d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b [m[1;92mF[m[1;92ma[m[1;92mls[m[1;92me[m[32m d e[m
 
-Negate at src/Example/ConstFnLib.hs:81:54-55 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+Negate at src/Example/ConstFnLib.hs:89:54-55 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b[m[31m [m[31mc[m[31m d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32mc[m[1;92m)[m[32m d e[m
 
-ConstBool at src/Example/ConstFnLib.hs:81:56-57 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:56-57 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c [m[1;91md[m[31m e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c [m[1;92mT[m[1;92mr[m[1;92mu[m[1;92me[m[32m e[m
 
-ConstBool at src/Example/ConstFnLib.hs:81:56-57 #2
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:56-57 #2
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c [m[1;91md[m[31m e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c [m[1;92mF[m[1;92ma[m[1;92mls[m[1;92me[m[32m e[m
 
-Negate at src/Example/ConstFnLib.hs:81:56-57 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+Negate at src/Example/ConstFnLib.hs:89:56-57 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c[m[31m [m[31md[m[31m e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32md[m[1;92m)[m[32m e[m
 
-ConstBool at src/Example/ConstFnLib.hs:81:58-59 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:58-59 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d [m[31me[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d [m[1;92mT[m[1;92mr[m[1;92mu[m[32me[m
 
-ConstBool at src/Example/ConstFnLib.hs:81:58-59 #2
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:58-59 #2
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d [m[31me[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d [m[1;92mF[m[1;92ma[m[1;92ml[m[1;92ms[m[32me[m
 
-Negate at src/Example/ConstFnLib.hs:81:58-59 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+Negate at src/Example/ConstFnLib.hs:89:58-59 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d[m[31m [m[31me[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = majorityOf5 a b c d[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32me[m[1;92m)[m
 
-ConstBool at src/Example/ConstFnLib.hs:81:38-59 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:38-59 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) = [m[1;91mm[m[1;91ma[m[1;91mj[m[1;91mo[m[31mr[m[1;91mityOf[m[1;91m5 a b[m[1;91m c [m[1;91md[m[41m [m[31me[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) = [m[1;92mT[m[32mr[m[1;92mu[m[32me[m
 
-ConstBool at src/Example/ConstFnLib.hs:81:38-59 #2
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+ConstBool at src/Example/ConstFnLib.hs:89:38-59 #2
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) =[m[41m [m[1;91mm[m[1;91ma[m[1;91mjor[m[1;91mityOf[m[1;91m5[m[31m [m[31ma[m[41m [m[1;91mb[m[1;91m c [m[1;91md[m[41m [m[31me[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) =[m[32m [m[1;92mF[m[32ma[m[1;92mls[m[32me[m
 
-Negate at src/Example/ConstFnLib.hs:81:38-59 #1
-[36m@@ -78,4 +78,4 @@[m
- --     @(\\_ _ _ _ _ -> False)@ mutants.  At a non-infix site this uses
- --     the plain 'TokenReplace' delta (no 'ReplaceOuterSpan' is needed).
+Negate at src/Example/ConstFnLib.hs:89:38-59 #1
+[36m@@ -86,4 +86,4 @@[m
+ -- behaviour.
+ {-# ANN majorityOf5Wrapper ("DisableMutation: SwitchFunctionArguments" :: String) #-}
  majorityOf5Wrapper :: (Bool, Bool, Bool, Bool, Bool) -> Bool
 [31m-[m[31mmajorityOf5Wrapper (a, b, c, d, e) =[m[31m [m[31mmajorityOf5 a b c d e[m
 [32m+[m[32mmajorityOf5Wrapper (a, b, c, d, e) =[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32mmajorityOf5 a b c d e[m[1;92m)[m
@@ -670,10 +670,10 @@ Negate at src/Example/ConstFnLib.hs:55:15-25 #1
  -- | A wrapper around 'implies' whose body references 'implies' at arity 2
  -- as a bare (un-applied) name.
 
-ConstBool at src/Example/ConstFnLib.hs:65:30-31 #1
-[36m@@ -62,7 +62,7 @@[m
- --   * 'ConstBool' arity 2 produces @(\\_ _ -> True)@ and
- --     @(\\_ _ -> False)@ mutants.
+ConstBool at src/Example/ConstFnLib.hs:67:30-31 #1
+[36m@@ -64,7 +64,7 @@[m
+ --   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments
+ --     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.
  impliesPair :: (Bool, Bool) -> Bool
 [31m-[m[31mimpliesPair (a, b) = implies [m[1;91ma[m[31m b[m
 [32m+[m[32mimpliesPair (a, b) = implies [m[1;92mT[m[1;92mr[m[1;92mu[m[1;92me[m[32m b[m
@@ -681,10 +681,10 @@ ConstBool at src/Example/ConstFnLib.hs:65:30-31 #1
  -- | A 5-argument predicate.  Used to confirm the 'ConstBool' arity-5
  -- mutation produces a well-formed prefix-form preview.
 
-ConstBool at src/Example/ConstFnLib.hs:65:30-31 #2
-[36m@@ -62,7 +62,7 @@[m
- --   * 'ConstBool' arity 2 produces @(\\_ _ -> True)@ and
- --     @(\\_ _ -> False)@ mutants.
+ConstBool at src/Example/ConstFnLib.hs:67:30-31 #2
+[36m@@ -64,7 +64,7 @@[m
+ --   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments
+ --     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.
  impliesPair :: (Bool, Bool) -> Bool
 [31m-[m[31mimpliesPair (a, b) = implies [m[31ma[m[31m b[m
 [32m+[m[32mimpliesPair (a, b) = implies [m[1;92mF[m[32ma[m[1;92ml[m[1;92ms[m[1;92me[m[32m b[m
@@ -692,10 +692,10 @@ ConstBool at src/Example/ConstFnLib.hs:65:30-31 #2
  -- | A 5-argument predicate.  Used to confirm the 'ConstBool' arity-5
  -- mutation produces a well-formed prefix-form preview.
 
-Negate at src/Example/ConstFnLib.hs:65:30-31 #1
-[36m@@ -62,7 +62,7 @@[m
- --   * 'ConstBool' arity 2 produces @(\\_ _ -> True)@ and
- --     @(\\_ _ -> False)@ mutants.
+Negate at src/Example/ConstFnLib.hs:67:30-31 #1
+[36m@@ -64,7 +64,7 @@[m
+ --   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments
+ --     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.
  impliesPair :: (Bool, Bool) -> Bool
 [31m-[m[31mimpliesPair (a, b) = implies[m[31m [m[31ma[m[31m b[m
 [32m+[m[32mimpliesPair (a, b) = implies[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32ma[m[1;92m)[m[32m b[m
@@ -703,10 +703,10 @@ Negate at src/Example/ConstFnLib.hs:65:30-31 #1
  -- | A 5-argument predicate.  Used to confirm the 'ConstBool' arity-5
  -- mutation produces a well-formed prefix-form preview.
 
-ConstBool at src/Example/ConstFnLib.hs:65:32-33 #1
-[36m@@ -62,7 +62,7 @@[m
- --   * 'ConstBool' arity 2 produces @(\\_ _ -> True)@ and
- --     @(\\_ _ -> False)@ mutants.
+ConstBool at src/Example/ConstFnLib.hs:67:32-33 #1
+[36m@@ -64,7 +64,7 @@[m
+ --   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments
+ --     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.
  impliesPair :: (Bool, Bool) -> Bool
 [31m-[m[31mimpliesPair (a, b) = implies a [m[1;91mb[m
 [32m+[m[32mimpliesPair (a, b) = implies a [m[1;92mT[m[1;92mr[m[1;92mu[m[1;92me[m
@@ -714,10 +714,10 @@ ConstBool at src/Example/ConstFnLib.hs:65:32-33 #1
  -- | A 5-argument predicate.  Used to confirm the 'ConstBool' arity-5
  -- mutation produces a well-formed prefix-form preview.
 
-ConstBool at src/Example/ConstFnLib.hs:65:32-33 #2
-[36m@@ -62,7 +62,7 @@[m
- --   * 'ConstBool' arity 2 produces @(\\_ _ -> True)@ and
- --     @(\\_ _ -> False)@ mutants.
+ConstBool at src/Example/ConstFnLib.hs:67:32-33 #2
+[36m@@ -64,7 +64,7 @@[m
+ --   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments
+ --     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.
  impliesPair :: (Bool, Bool) -> Bool
 [31m-[m[31mimpliesPair (a, b) = implies a [m[1;91mb[m
 [32m+[m[32mimpliesPair (a, b) = implies a [m[1;92mF[m[1;92ma[m[1;92mlse[m
@@ -725,10 +725,10 @@ ConstBool at src/Example/ConstFnLib.hs:65:32-33 #2
  -- | A 5-argument predicate.  Used to confirm the 'ConstBool' arity-5
  -- mutation produces a well-formed prefix-form preview.
 
-Negate at src/Example/ConstFnLib.hs:65:32-33 #1
-[36m@@ -62,7 +62,7 @@[m
- --   * 'ConstBool' arity 2 produces @(\\_ _ -> True)@ and
- --     @(\\_ _ -> False)@ mutants.
+Negate at src/Example/ConstFnLib.hs:67:32-33 #1
+[36m@@ -64,7 +64,7 @@[m
+ --   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments
+ --     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.
  impliesPair :: (Bool, Bool) -> Bool
 [31m-[m[31mimpliesPair (a, b) = implies a[m[31m [m[31mb[m
 [32m+[m[32mimpliesPair (a, b) = implies a[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32mb[m[1;92m)[m
@@ -736,10 +736,10 @@ Negate at src/Example/ConstFnLib.hs:65:32-33 #1
  -- | A 5-argument predicate.  Used to confirm the 'ConstBool' arity-5
  -- mutation produces a well-formed prefix-form preview.
 
-ConstBool at src/Example/ConstFnLib.hs:65:22-33 #1
-[36m@@ -62,7 +62,7 @@[m
- --   * 'ConstBool' arity 2 produces @(\\_ _ -> True)@ and
- --     @(\\_ _ -> False)@ mutants.
+ConstBool at src/Example/ConstFnLib.hs:67:22-33 #1
+[36m@@ -64,7 +64,7 @@[m
+ --   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments
+ --     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.
  impliesPair :: (Bool, Bool) -> Bool
 [31m-[m[31mimpliesPair (a, b) = [m[1;91mi[m[1;91mmpl[m[1;91mi[m[31me[m[1;91ms[m[41m [m[1;91ma b[m
 [32m+[m[32mimpliesPair (a, b) = [m[1;92mT[m[1;92mru[m[32me[m
@@ -747,10 +747,10 @@ ConstBool at src/Example/ConstFnLib.hs:65:22-33 #1
  -- | A 5-argument predicate.  Used to confirm the 'ConstBool' arity-5
  -- mutation produces a well-formed prefix-form preview.
 
-ConstBool at src/Example/ConstFnLib.hs:65:22-33 #2
-[36m@@ -62,7 +62,7 @@[m
- --   * 'ConstBool' arity 2 produces @(\\_ _ -> True)@ and
- --     @(\\_ _ -> False)@ mutants.
+ConstBool at src/Example/ConstFnLib.hs:67:22-33 #2
+[36m@@ -64,7 +64,7 @@[m
+ --   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments
+ --     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.
  impliesPair :: (Bool, Bool) -> Bool
 [31m-[m[31mimpliesPair (a, b) = [m[1;91mi[m[1;91mm[m[1;91mp[m[31ml[m[1;91mi[m[1;91me[m[31ms[m[41m [m[1;91ma[m[41m [m[1;91mb[m
 [32m+[m[32mimpliesPair (a, b) = [m[1;92mFa[m[32ml[m[32ms[m[1;92me[m
@@ -758,13 +758,24 @@ ConstBool at src/Example/ConstFnLib.hs:65:22-33 #2
  -- | A 5-argument predicate.  Used to confirm the 'ConstBool' arity-5
  -- mutation produces a well-formed prefix-form preview.
 
-Negate at src/Example/ConstFnLib.hs:65:22-33 #1
-[36m@@ -62,7 +62,7 @@[m
- --   * 'ConstBool' arity 2 produces @(\\_ _ -> True)@ and
- --     @(\\_ _ -> False)@ mutants.
+Negate at src/Example/ConstFnLib.hs:67:22-33 #1
+[36m@@ -64,7 +64,7 @@[m
+ --   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments
+ --     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.
  impliesPair :: (Bool, Bool) -> Bool
 [31m-[m[31mimpliesPair (a, b) =[m[31m [m[31mimplies a b[m
 [32m+[m[32mimpliesPair (a, b) =[m[42m [m[1;92mn[m[1;92mo[m[1;92mt[m[32m [m[1;92m([m[32mimplies a b[m[1;92m)[m
+ 
+ -- | A 5-argument predicate.  Used to confirm the 'ConstBool' arity-5
+ -- mutation produces a well-formed prefix-form preview.
+
+SwitchFunctionArguments at src/Example/ConstFnLib.hs:67:22-33 #1
+[36m@@ -64,7 +64,7 @@[m
+ --   * 'SwitchFunctionArguments' swaps the two 'Bool' arguments
+ --     (@implies b a@); 'implies' is asymmetric, so the spec tests kill it.
+ impliesPair :: (Bool, Bool) -> Bool
+[31m-[m[31mimpliesPair (a, b) = implies[m[41m [m[1;91ma[m[31m b[m
+[32m+[m[32mimpliesPair (a, b) = implies[m[32m b[m[1;92m a[m
  
  -- | A 5-argument predicate.  Used to confirm the 'ConstBool' arity-5
  -- mutation produces a well-formed prefix-form preview.

--- a/sydtest-mutation-example/test_resources/manifests/Example.DoLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.DoLib.json
@@ -1,6 +1,7 @@
 [
   [
     {
+      "binding": "greet",
       "col_end": 27,
       "col_start": 14,
       "context_after": [
@@ -39,6 +40,7 @@
   ],
   [
     {
+      "binding": "greet",
       "col_end": 19,
       "col_start": 12,
       "context_after": [
@@ -76,6 +78,7 @@
   ],
   [
     {
+      "binding": "greet",
       "col_end": 14,
       "col_start": 10,
       "context_after": [
@@ -110,6 +113,7 @@
       ]
     },
     {
+      "binding": "greet",
       "col_end": 14,
       "col_start": 10,
       "context_after": [
@@ -146,6 +150,7 @@
   ],
   [
     {
+      "binding": "greet",
       "col_end": 14,
       "col_start": 10,
       "context_after": [
@@ -182,6 +187,7 @@
   ],
   [
     {
+      "binding": "greet",
       "col_end": 28,
       "col_start": 25,
       "context_after": [
@@ -218,6 +224,7 @@
   ],
   [
     {
+      "binding": "greet",
       "col_end": 16,
       "col_start": 12,
       "context_after": [],
@@ -252,6 +259,7 @@
   ],
   [
     {
+      "binding": "greet",
       "col_end": 41,
       "col_start": 7,
       "context_after": [
@@ -286,6 +294,7 @@
   ],
   [
     {
+      "binding": "greet",
       "col_end": 16,
       "col_start": 10,
       "context_after": [],

--- a/sydtest-mutation-example/test_resources/manifests/Example.FunctionExceptionLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.FunctionExceptionLib.json
@@ -1,6 +1,7 @@
 [
   [
     {
+      "binding": "addOneArithDisabled",
       "col_end": 30,
       "col_start": 29,
       "context_after": [
@@ -37,6 +38,7 @@
       ]
     },
     {
+      "binding": "addOneArithDisabled",
       "col_end": 30,
       "col_start": 29,
       "context_after": [

--- a/sydtest-mutation-example/test_resources/manifests/Example.Lib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.Lib.json
@@ -1,6 +1,7 @@
 [
   [
     {
+      "binding": "addOne",
       "col_end": 17,
       "col_start": 16,
       "context_after": [],
@@ -33,6 +34,7 @@
       ]
     },
     {
+      "binding": "addOne",
       "col_end": 17,
       "col_start": 16,
       "context_after": [],
@@ -67,6 +69,7 @@
   ],
   [
     {
+      "binding": "addOne",
       "col_end": 17,
       "col_start": 12,
       "context_after": [],
@@ -99,6 +102,7 @@
       ]
     },
     {
+      "binding": "addOne",
       "col_end": 17,
       "col_start": 12,
       "context_after": [],

--- a/sydtest-mutation-example/test_resources/manifests/Example.ListLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.ListLib.json
@@ -1,6 +1,7 @@
 [
   [
     {
+      "binding": "tripleConcat",
       "col_end": 31,
       "col_start": 30,
       "context_after": [],
@@ -35,6 +36,7 @@
   ],
   [
     {
+      "binding": "tripleConcat",
       "col_end": 34,
       "col_start": 33,
       "context_after": [],
@@ -69,6 +71,7 @@
   ],
   [
     {
+      "binding": "tripleConcat",
       "col_end": 37,
       "col_start": 36,
       "context_after": [],
@@ -103,6 +106,7 @@
   ],
   [
     {
+      "binding": "tripleConcat",
       "col_end": 38,
       "col_start": 29,
       "context_after": [],
@@ -137,6 +141,7 @@
   ],
   [
     {
+      "binding": "tripleConcat",
       "col_end": 38,
       "col_start": 29,
       "context_after": [],
@@ -167,6 +172,7 @@
       ]
     },
     {
+      "binding": "tripleConcat",
       "col_end": 38,
       "col_start": 29,
       "context_after": [],
@@ -197,6 +203,7 @@
       ]
     },
     {
+      "binding": "tripleConcat",
       "col_end": 38,
       "col_start": 29,
       "context_after": [],
@@ -229,6 +236,7 @@
   ],
   [
     {
+      "binding": "tripleConcat",
       "col_end": 38,
       "col_start": 22,
       "context_after": [],
@@ -263,6 +271,7 @@
   ],
   [
     {
+      "binding": "pairConcat",
       "col_end": 27,
       "col_start": 26,
       "context_after": [
@@ -301,6 +310,7 @@
   ],
   [
     {
+      "binding": "pairConcat",
       "col_end": 30,
       "col_start": 29,
       "context_after": [
@@ -339,6 +349,7 @@
   ],
   [
     {
+      "binding": "pairConcat",
       "col_end": 31,
       "col_start": 25,
       "context_after": [
@@ -377,6 +388,7 @@
   ],
   [
     {
+      "binding": "pairConcat",
       "col_end": 31,
       "col_start": 25,
       "context_after": [
@@ -411,6 +423,7 @@
       ]
     },
     {
+      "binding": "pairConcat",
       "col_end": 31,
       "col_start": 25,
       "context_after": [
@@ -447,6 +460,7 @@
   ],
   [
     {
+      "binding": "pairConcat",
       "col_end": 31,
       "col_start": 18,
       "context_after": [

--- a/sydtest-mutation-example/test_resources/manifests/Example.LocalDisableLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.LocalDisableLib.json
@@ -1,6 +1,7 @@
 [
   [
     {
+      "binding": "withBindKept",
       "col_end": 20,
       "col_start": 19,
       "context_after": [
@@ -35,6 +36,7 @@
       ]
     },
     {
+      "binding": "withBindKept",
       "col_end": 20,
       "col_start": 19,
       "context_after": [
@@ -71,6 +73,7 @@
   ],
   [
     {
+      "binding": "withBindKept",
       "col_end": 20,
       "col_start": 19,
       "context_after": [
@@ -107,6 +110,7 @@
   ],
   [
     {
+      "binding": "withBindKept",
       "col_end": 13,
       "col_start": 8,
       "context_after": [],
@@ -139,6 +143,7 @@
       ]
     },
     {
+      "binding": "withBindKept",
       "col_end": 13,
       "col_start": 8,
       "context_after": [],
@@ -173,6 +178,7 @@
   ],
   [
     {
+      "binding": "withBindKept",
       "col_end": 13,
       "col_start": 8,
       "context_after": [],
@@ -207,6 +213,7 @@
   ],
   [
     {
+      "binding": "withBindDisabled",
       "col_end": 13,
       "col_start": 8,
       "context_after": [
@@ -243,6 +250,7 @@
       ]
     },
     {
+      "binding": "withBindDisabled",
       "col_end": 13,
       "col_start": 8,
       "context_after": [
@@ -281,6 +289,7 @@
   ],
   [
     {
+      "binding": "withBindDisabled",
       "col_end": 13,
       "col_start": 8,
       "context_after": [
@@ -319,6 +328,7 @@
   ],
   [
     {
+      "binding": "withInnerKept",
       "col_end": 20,
       "col_start": 19,
       "context_after": [
@@ -355,6 +365,7 @@
       ]
     },
     {
+      "binding": "withInnerKept",
       "col_end": 20,
       "col_start": 19,
       "context_after": [
@@ -393,6 +404,7 @@
   ],
   [
     {
+      "binding": "withInnerKept",
       "col_end": 20,
       "col_start": 19,
       "context_after": [
@@ -431,6 +443,7 @@
   ],
   [
     {
+      "binding": "withInnerKept",
       "col_end": 20,
       "col_start": 15,
       "context_after": [
@@ -467,6 +480,7 @@
       ]
     },
     {
+      "binding": "withInnerKept",
       "col_end": 20,
       "col_start": 15,
       "context_after": [
@@ -505,6 +519,7 @@
   ],
   [
     {
+      "binding": "withInnerKept",
       "col_end": 20,
       "col_start": 15,
       "context_after": [
@@ -543,6 +558,7 @@
   ],
   [
     {
+      "binding": "withInnerKept",
       "col_end": 12,
       "col_start": 7,
       "context_after": [
@@ -579,6 +595,7 @@
       ]
     },
     {
+      "binding": "withInnerKept",
       "col_end": 12,
       "col_start": 7,
       "context_after": [
@@ -617,6 +634,7 @@
   ],
   [
     {
+      "binding": "withInnerKept",
       "col_end": 12,
       "col_start": 7,
       "context_after": [
@@ -655,6 +673,7 @@
   ],
   [
     {
+      "binding": "withInnerKept",
       "col_end": 12,
       "col_start": 3,
       "context_after": [
@@ -692,6 +711,7 @@
       ]
     },
     {
+      "binding": "withInnerKept",
       "col_end": 12,
       "col_start": 3,
       "context_after": [
@@ -731,6 +751,7 @@
   ],
   [
     {
+      "binding": "withInnerKept",
       "col_end": 12,
       "col_start": 3,
       "context_after": [
@@ -771,6 +792,7 @@
   ],
   [
     {
+      "binding": "withInnerBoolLitDisabled",
       "col_end": 20,
       "col_start": 19,
       "context_after": [
@@ -809,6 +831,7 @@
   ],
   [
     {
+      "binding": "withInnerBoolLitDisabled",
       "col_end": 20,
       "col_start": 15,
       "context_after": [
@@ -847,6 +870,7 @@
   ],
   [
     {
+      "binding": "withInnerBoolLitDisabled",
       "col_end": 12,
       "col_start": 7,
       "context_after": [
@@ -883,6 +907,7 @@
       ]
     },
     {
+      "binding": "withInnerBoolLitDisabled",
       "col_end": 12,
       "col_start": 7,
       "context_after": [
@@ -921,6 +946,7 @@
   ],
   [
     {
+      "binding": "withInnerBoolLitDisabled",
       "col_end": 12,
       "col_start": 7,
       "context_after": [
@@ -959,6 +985,7 @@
   ],
   [
     {
+      "binding": "withInnerBoolLitDisabled",
       "col_end": 12,
       "col_start": 3,
       "context_after": [
@@ -996,6 +1023,7 @@
       ]
     },
     {
+      "binding": "withInnerBoolLitDisabled",
       "col_end": 12,
       "col_start": 3,
       "context_after": [
@@ -1035,6 +1063,7 @@
   ],
   [
     {
+      "binding": "withInnerBoolLitDisabled",
       "col_end": 12,
       "col_start": 3,
       "context_after": [
@@ -1075,6 +1104,7 @@
   ],
   [
     {
+      "binding": "withInnerDisabled",
       "col_end": 12,
       "col_start": 7,
       "context_after": [
@@ -1111,6 +1141,7 @@
       ]
     },
     {
+      "binding": "withInnerDisabled",
       "col_end": 12,
       "col_start": 7,
       "context_after": [
@@ -1149,6 +1180,7 @@
   ],
   [
     {
+      "binding": "withInnerDisabled",
       "col_end": 12,
       "col_start": 7,
       "context_after": [
@@ -1187,6 +1219,7 @@
   ],
   [
     {
+      "binding": "withInnerDisabled",
       "col_end": 12,
       "col_start": 3,
       "context_after": [
@@ -1224,6 +1257,7 @@
       ]
     },
     {
+      "binding": "withInnerDisabled",
       "col_end": 12,
       "col_start": 3,
       "context_after": [
@@ -1263,6 +1297,7 @@
   ],
   [
     {
+      "binding": "withInnerDisabled",
       "col_end": 12,
       "col_start": 3,
       "context_after": [

--- a/sydtest-mutation-example/test_resources/manifests/Example.LogicLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.LogicLib.json
@@ -1,6 +1,7 @@
 [
   [
     {
+      "binding": "eitherPositive",
       "col_end": 27,
       "col_start": 26,
       "context_after": [],
@@ -35,6 +36,7 @@
   ],
   [
     {
+      "binding": "eitherPositive",
       "col_end": 27,
       "col_start": 22,
       "context_after": [],
@@ -67,6 +69,7 @@
       ]
     },
     {
+      "binding": "eitherPositive",
       "col_end": 27,
       "col_start": 22,
       "context_after": [],
@@ -99,6 +102,7 @@
       ]
     },
     {
+      "binding": "eitherPositive",
       "col_end": 27,
       "col_start": 22,
       "context_after": [],
@@ -133,6 +137,7 @@
   ],
   [
     {
+      "binding": "eitherPositive",
       "col_end": 27,
       "col_start": 22,
       "context_after": [],
@@ -165,6 +170,7 @@
       ]
     },
     {
+      "binding": "eitherPositive",
       "col_end": 27,
       "col_start": 22,
       "context_after": [],
@@ -199,6 +205,7 @@
   ],
   [
     {
+      "binding": "eitherPositive",
       "col_end": 27,
       "col_start": 22,
       "context_after": [],
@@ -233,6 +240,7 @@
   ],
   [
     {
+      "binding": "eitherPositive",
       "col_end": 36,
       "col_start": 35,
       "context_after": [],
@@ -267,6 +275,7 @@
   ],
   [
     {
+      "binding": "eitherPositive",
       "col_end": 36,
       "col_start": 31,
       "context_after": [],
@@ -299,6 +308,7 @@
       ]
     },
     {
+      "binding": "eitherPositive",
       "col_end": 36,
       "col_start": 31,
       "context_after": [],
@@ -331,6 +341,7 @@
       ]
     },
     {
+      "binding": "eitherPositive",
       "col_end": 36,
       "col_start": 31,
       "context_after": [],
@@ -365,6 +376,7 @@
   ],
   [
     {
+      "binding": "eitherPositive",
       "col_end": 36,
       "col_start": 31,
       "context_after": [],
@@ -397,6 +409,7 @@
       ]
     },
     {
+      "binding": "eitherPositive",
       "col_end": 36,
       "col_start": 31,
       "context_after": [],
@@ -431,6 +444,7 @@
   ],
   [
     {
+      "binding": "eitherPositive",
       "col_end": 36,
       "col_start": 31,
       "context_after": [],
@@ -465,6 +479,7 @@
   ],
   [
     {
+      "binding": "eitherPositive",
       "col_end": 36,
       "col_start": 22,
       "context_after": [],
@@ -497,6 +512,7 @@
       ]
     },
     {
+      "binding": "eitherPositive",
       "col_end": 36,
       "col_start": 22,
       "context_after": [],
@@ -531,6 +547,7 @@
   ],
   [
     {
+      "binding": "eitherPositive",
       "col_end": 36,
       "col_start": 22,
       "context_after": [],
@@ -565,6 +582,7 @@
   ],
   [
     {
+      "binding": "eitherPositive",
       "col_end": 36,
       "col_start": 22,
       "context_after": [],
@@ -599,6 +617,7 @@
   ],
   [
     {
+      "binding": "bothPositive",
       "col_end": 25,
       "col_start": 24,
       "context_after": [
@@ -637,6 +656,7 @@
   ],
   [
     {
+      "binding": "bothPositive",
       "col_end": 25,
       "col_start": 20,
       "context_after": [
@@ -673,6 +693,7 @@
       ]
     },
     {
+      "binding": "bothPositive",
       "col_end": 25,
       "col_start": 20,
       "context_after": [
@@ -709,6 +730,7 @@
       ]
     },
     {
+      "binding": "bothPositive",
       "col_end": 25,
       "col_start": 20,
       "context_after": [
@@ -747,6 +769,7 @@
   ],
   [
     {
+      "binding": "bothPositive",
       "col_end": 25,
       "col_start": 20,
       "context_after": [
@@ -783,6 +806,7 @@
       ]
     },
     {
+      "binding": "bothPositive",
       "col_end": 25,
       "col_start": 20,
       "context_after": [
@@ -821,6 +845,7 @@
   ],
   [
     {
+      "binding": "bothPositive",
       "col_end": 25,
       "col_start": 20,
       "context_after": [
@@ -859,6 +884,7 @@
   ],
   [
     {
+      "binding": "bothPositive",
       "col_end": 34,
       "col_start": 33,
       "context_after": [
@@ -897,6 +923,7 @@
   ],
   [
     {
+      "binding": "bothPositive",
       "col_end": 34,
       "col_start": 29,
       "context_after": [
@@ -933,6 +960,7 @@
       ]
     },
     {
+      "binding": "bothPositive",
       "col_end": 34,
       "col_start": 29,
       "context_after": [
@@ -969,6 +997,7 @@
       ]
     },
     {
+      "binding": "bothPositive",
       "col_end": 34,
       "col_start": 29,
       "context_after": [
@@ -1007,6 +1036,7 @@
   ],
   [
     {
+      "binding": "bothPositive",
       "col_end": 34,
       "col_start": 29,
       "context_after": [
@@ -1043,6 +1073,7 @@
       ]
     },
     {
+      "binding": "bothPositive",
       "col_end": 34,
       "col_start": 29,
       "context_after": [
@@ -1081,6 +1112,7 @@
   ],
   [
     {
+      "binding": "bothPositive",
       "col_end": 34,
       "col_start": 29,
       "context_after": [
@@ -1119,6 +1151,7 @@
   ],
   [
     {
+      "binding": "bothPositive",
       "col_end": 34,
       "col_start": 20,
       "context_after": [
@@ -1155,6 +1188,7 @@
       ]
     },
     {
+      "binding": "bothPositive",
       "col_end": 34,
       "col_start": 20,
       "context_after": [
@@ -1193,6 +1227,7 @@
   ],
   [
     {
+      "binding": "bothPositive",
       "col_end": 34,
       "col_start": 20,
       "context_after": [
@@ -1231,6 +1266,7 @@
   ],
   [
     {
+      "binding": "bothPositive",
       "col_end": 34,
       "col_start": 20,
       "context_after": [

--- a/sydtest-mutation-example/test_resources/manifests/Example.OtherwiseLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.OtherwiseLib.json
@@ -1,6 +1,7 @@
 [
   [
     {
+      "binding": "classify",
       "col_end": 10,
       "col_start": 9,
       "context_after": [
@@ -38,6 +39,7 @@
   ],
   [
     {
+      "binding": "classify",
       "col_end": 10,
       "col_start": 5,
       "context_after": [
@@ -73,6 +75,7 @@
       ]
     },
     {
+      "binding": "classify",
       "col_end": 10,
       "col_start": 5,
       "context_after": [
@@ -108,6 +111,7 @@
       ]
     },
     {
+      "binding": "classify",
       "col_end": 10,
       "col_start": 5,
       "context_after": [
@@ -145,6 +149,7 @@
   ],
   [
     {
+      "binding": "classify",
       "col_end": 10,
       "col_start": 5,
       "context_after": [
@@ -182,6 +187,7 @@
   ],
   [
     {
+      "binding": "classify",
       "col_end": 10,
       "col_start": 5,
       "context_after": [
@@ -219,6 +225,7 @@
   ],
   [
     {
+      "binding": "classify",
       "col_end": 23,
       "col_start": 13,
       "context_after": [
@@ -256,6 +263,7 @@
   ],
   [
     {
+      "binding": "classify",
       "col_end": 11,
       "col_start": 10,
       "context_after": [
@@ -292,6 +300,7 @@
   ],
   [
     {
+      "binding": "classify",
       "col_end": 11,
       "col_start": 5,
       "context_after": [
@@ -328,6 +337,7 @@
   ],
   [
     {
+      "binding": "classify",
       "col_end": 11,
       "col_start": 5,
       "context_after": [
@@ -364,6 +374,7 @@
   ],
   [
     {
+      "binding": "classify",
       "col_end": 20,
       "col_start": 14,
       "context_after": [
@@ -400,6 +411,7 @@
   ],
   [
     {
+      "binding": "classify",
       "col_end": 27,
       "col_start": 17,
       "context_after": [],

--- a/sydtest-mutation-example/test_resources/manifests/Example.SwitchArgsLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.SwitchArgsLib.json
@@ -1,6 +1,7 @@
 [
   [
     {
+      "binding": "makeColour",
       "col_end": 29,
       "col_start": 20,
       "context_after": [
@@ -37,6 +38,7 @@
       ]
     },
     {
+      "binding": "makeColour",
       "col_end": 29,
       "col_start": 20,
       "context_after": [
@@ -73,6 +75,7 @@
       ]
     },
     {
+      "binding": "makeColour",
       "col_end": 29,
       "col_start": 20,
       "context_after": [
@@ -111,6 +114,7 @@
   ],
   [
     {
+      "binding": "parenDivide",
       "col_end": 32,
       "col_start": 25,
       "context_after": [
@@ -134,6 +138,7 @@
         "1"
       ],
       "line": 21,
+      "mitigation": "If `div` is symmetric in these arguments this is an equivalent mutant that no test can kill; add `div` to this operator's `skip-calls-to` config to suppress it.",
       "module": "Example.SwitchArgsLib",
       "mutated_lines": [
         "parenDivide a b = succ (div b a)"
@@ -149,6 +154,7 @@
   ],
   [
     {
+      "binding": "divideThe",
       "col_end": 24,
       "col_start": 17,
       "context_after": [
@@ -172,6 +178,7 @@
         "1"
       ],
       "line": 14,
+      "mitigation": "If `div` is symmetric in these arguments this is an equivalent mutant that no test can kill; add `div` to this operator's `skip-calls-to` config to suppress it.",
       "module": "Example.SwitchArgsLib",
       "mutated_lines": [
         "divideThe a b = div b a"

--- a/sydtest-mutation-example/test_resources/manifests/Example.SwitchArgsLib.json
+++ b/sydtest-mutation-example/test_resources/manifests/Example.SwitchArgsLib.json
@@ -1,0 +1,188 @@
+[
+  [
+    {
+      "col_end": 29,
+      "col_start": 20,
+      "context_after": [
+        "",
+        "-- | The same constructor applied to three textually identical arguments.",
+        "-- Every swap would be a no-op, so 'SwitchFunctionArguments' produces nothing."
+      ],
+      "context_before": [
+        "-- | All three arguments are 'Int', so 'SwitchFunctionArguments' produces one",
+        "-- mutant per pair: swapping (r, g), (r, b), and (g, b).",
+        "makeColour :: Int -> Int -> Int -> RGB"
+      ],
+      "end_line": 30,
+      "id": [
+        "Example.SwitchArgsLib",
+        "SwitchFunctionArguments",
+        "30",
+        "20",
+        "29",
+        "g r",
+        "1"
+      ],
+      "line": 30,
+      "module": "Example.SwitchArgsLib",
+      "mutated_lines": [
+        "makeColour r g b = RGB g r b"
+      ],
+      "operator": "SwitchFunctionArguments",
+      "original": "r g",
+      "replacement": "g r",
+      "source_file": "src/Example/SwitchArgsLib.hs",
+      "source_lines": [
+        "makeColour r g b = RGB r g b"
+      ]
+    },
+    {
+      "col_end": 29,
+      "col_start": 20,
+      "context_after": [
+        "",
+        "-- | The same constructor applied to three textually identical arguments.",
+        "-- Every swap would be a no-op, so 'SwitchFunctionArguments' produces nothing."
+      ],
+      "context_before": [
+        "-- | All three arguments are 'Int', so 'SwitchFunctionArguments' produces one",
+        "-- mutant per pair: swapping (r, g), (r, b), and (g, b).",
+        "makeColour :: Int -> Int -> Int -> RGB"
+      ],
+      "end_line": 30,
+      "id": [
+        "Example.SwitchArgsLib",
+        "SwitchFunctionArguments",
+        "30",
+        "20",
+        "29",
+        "b r",
+        "2"
+      ],
+      "line": 30,
+      "module": "Example.SwitchArgsLib",
+      "mutated_lines": [
+        "makeColour r g b = RGB b g r"
+      ],
+      "operator": "SwitchFunctionArguments",
+      "original": "r b",
+      "replacement": "b r",
+      "source_file": "src/Example/SwitchArgsLib.hs",
+      "source_lines": [
+        "makeColour r g b = RGB r g b"
+      ]
+    },
+    {
+      "col_end": 29,
+      "col_start": 20,
+      "context_after": [
+        "",
+        "-- | The same constructor applied to three textually identical arguments.",
+        "-- Every swap would be a no-op, so 'SwitchFunctionArguments' produces nothing."
+      ],
+      "context_before": [
+        "-- | All three arguments are 'Int', so 'SwitchFunctionArguments' produces one",
+        "-- mutant per pair: swapping (r, g), (r, b), and (g, b).",
+        "makeColour :: Int -> Int -> Int -> RGB"
+      ],
+      "end_line": 30,
+      "id": [
+        "Example.SwitchArgsLib",
+        "SwitchFunctionArguments",
+        "30",
+        "20",
+        "29",
+        "b g",
+        "3"
+      ],
+      "line": 30,
+      "module": "Example.SwitchArgsLib",
+      "mutated_lines": [
+        "makeColour r g b = RGB r b g"
+      ],
+      "operator": "SwitchFunctionArguments",
+      "original": "g b",
+      "replacement": "b g",
+      "source_file": "src/Example/SwitchArgsLib.hs",
+      "source_lines": [
+        "makeColour r g b = RGB r g b"
+      ]
+    }
+  ],
+  [
+    {
+      "col_end": 32,
+      "col_start": 25,
+      "context_after": [
+        "",
+        "-- | A colour built from three 'Int' components.",
+        "data RGB = RGB Int Int Int"
+      ],
+      "context_before": [
+        "-- mutation must be produced exactly once -- not once for the parenthesis node",
+        "-- and once for the inner application.",
+        "parenDivide :: Int -> Int -> Int"
+      ],
+      "end_line": 21,
+      "id": [
+        "Example.SwitchArgsLib",
+        "SwitchFunctionArguments",
+        "21",
+        "25",
+        "32",
+        "b a",
+        "1"
+      ],
+      "line": 21,
+      "module": "Example.SwitchArgsLib",
+      "mutated_lines": [
+        "parenDivide a b = succ (div b a)"
+      ],
+      "operator": "SwitchFunctionArguments",
+      "original": "a b",
+      "replacement": "b a",
+      "source_file": "src/Example/SwitchArgsLib.hs",
+      "source_lines": [
+        "parenDivide a b = succ (div a b)"
+      ]
+    }
+  ],
+  [
+    {
+      "col_end": 24,
+      "col_start": 17,
+      "context_after": [
+        "",
+        "-- | A parenthesised application: the parentheses around @div a b@ are",
+        "-- required for precedence, so GHC keeps an 'HsPar' node around it.  The swap"
+      ],
+      "context_before": [
+        "-- 'SwitchFunctionArguments' produces one mutant that swaps them: @div b a@",
+        "-- instead of @div a b@.",
+        "divideThe :: Int -> Int -> Int"
+      ],
+      "end_line": 14,
+      "id": [
+        "Example.SwitchArgsLib",
+        "SwitchFunctionArguments",
+        "14",
+        "17",
+        "24",
+        "b a",
+        "1"
+      ],
+      "line": 14,
+      "module": "Example.SwitchArgsLib",
+      "mutated_lines": [
+        "divideThe a b = div b a"
+      ],
+      "operator": "SwitchFunctionArguments",
+      "original": "a b",
+      "replacement": "b a",
+      "source_file": "src/Example/SwitchArgsLib.hs",
+      "source_lines": [
+        "divideThe a b = div a b"
+      ]
+    }
+  ]
+]

--- a/sydtest-mutation-example/test_resources/manifests/Example.SwitchArgsLib.txt
+++ b/sydtest-mutation-example/test_resources/manifests/Example.SwitchArgsLib.txt
@@ -1,0 +1,57 @@
+[36m# Example.SwitchArgsLib[m
+5 mutations in 3 groups
+
+SwitchFunctionArguments at src/Example/SwitchArgsLib.hs:30:20-29 #1
+[36m@@ -27,7 +27,7 @@[m
+ -- | All three arguments are 'Int', so 'SwitchFunctionArguments' produces one
+ -- mutant per pair: swapping (r, g), (r, b), and (g, b).
+ makeColour :: Int -> Int -> Int -> RGB
+[31m-[m[31mmakeColour r g b = RGB[m[41m [m[1;91mr[m[31m g[m[31m b[m
+[32m+[m[32mmakeColour r g b = RGB[m[32m g[m[42m [m[1;92mr[m[32m b[m
+ 
+ -- | The same constructor applied to three textually identical arguments.
+ -- Every swap would be a no-op, so 'SwitchFunctionArguments' produces nothing.
+
+SwitchFunctionArguments at src/Example/SwitchArgsLib.hs:30:20-29 #2
+[36m@@ -27,7 +27,7 @@[m
+ -- | All three arguments are 'Int', so 'SwitchFunctionArguments' produces one
+ -- mutant per pair: swapping (r, g), (r, b), and (g, b).
+ makeColour :: Int -> Int -> Int -> RGB
+[31m-[m[31mmakeColour r g b = RGB [m[1;91mr[m[31m g [m[1;91mb[m
+[32m+[m[32mmakeColour r g b = RGB [m[1;92mb[m[32m g [m[1;92mr[m
+ 
+ -- | The same constructor applied to three textually identical arguments.
+ -- Every swap would be a no-op, so 'SwitchFunctionArguments' produces nothing.
+
+SwitchFunctionArguments at src/Example/SwitchArgsLib.hs:30:20-29 #3
+[36m@@ -27,7 +27,7 @@[m
+ -- | All three arguments are 'Int', so 'SwitchFunctionArguments' produces one
+ -- mutant per pair: swapping (r, g), (r, b), and (g, b).
+ makeColour :: Int -> Int -> Int -> RGB
+[31m-[m[31mmakeColour r g b = RGB r[m[41m [m[1;91mg[m[31m b[m
+[32m+[m[32mmakeColour r g b = RGB r[m[32m b[m[1;92m g[m
+ 
+ -- | The same constructor applied to three textually identical arguments.
+ -- Every swap would be a no-op, so 'SwitchFunctionArguments' produces nothing.
+
+SwitchFunctionArguments at src/Example/SwitchArgsLib.hs:21:25-32 #1
+[36m@@ -18,7 +18,7 @@[m
+ -- mutation must be produced exactly once -- not once for the parenthesis node
+ -- and once for the inner application.
+ parenDivide :: Int -> Int -> Int
+[31m-[m[31mparenDivide a b = succ (div[m[41m [m[1;91ma[m[31m b[m[31m)[m
+[32m+[m[32mparenDivide a b = succ (div[m[32m b[m[42m [m[1;92ma[m[32m)[m
+ 
+ -- | A colour built from three 'Int' components.
+ data RGB = RGB Int Int Int
+
+SwitchFunctionArguments at src/Example/SwitchArgsLib.hs:14:17-24 #1
+[36m@@ -11,7 +11,7 @@[m
+ -- 'SwitchFunctionArguments' produces one mutant that swaps them: @div b a@
+ -- instead of @div a b@.
+ divideThe :: Int -> Int -> Int
+[31m-[m[31mdivideThe a b = div[m[41m [m[1;91ma[m[31m b[m
+[32m+[m[32mdivideThe a b = div[m[32m b[m[1;92m a[m
+ 
+ -- | A parenthesised application: the parentheses around @div a b@ are
+ -- required for precedence, so GHC keeps an 'HsPar' node around it.  The swap

--- a/sydtest-mutation-plugin/CHANGELOG.md
+++ b/sydtest-mutation-plugin/CHANGELOG.md
@@ -10,6 +10,23 @@
   maximal application spine is mutated, and pairs whose arguments have
   identical source text are skipped (swapping them would be a no-op).
 
+  Symmetric functions make this operator produce equivalent (unkillable)
+  mutants, so it reads a `skip-calls-to` list of function names from its
+  per-operator config and skips swapping the arguments of any call to a
+  listed function:
+
+  ```yaml
+  operators:
+    SwitchFunctionArguments:
+      skip-calls-to: [max, Data.Set.union]
+  ```
+
+* Mutations now carry an optional `mitigation` hint and the enclosing
+  `binding` name in the manifest.  `SwitchFunctionArguments` sets a mitigation
+  message pointing at `skip-calls-to`; the binding name lets the run report
+  print the exact `{-# ANN <binding> ("DisableMutation: <Operator>" ...) #-}`
+  annotation for each surviving mutation.
+
 ## [0.3.0.0] - 2026-06-09
 
 ### Added

--- a/sydtest-mutation-plugin/CHANGELOG.md
+++ b/sydtest-mutation-plugin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.4.0.0] - 2026-06-17
+
+### Added
+
+* A `SwitchFunctionArguments` mutation operator: at a prefix function (or
+  constructor) application, for every pair of value arguments that have the
+  same type, it emits a mutant that swaps those two arguments.  Only the
+  maximal application spine is mutated, and pairs whose arguments have
+  identical source text are skipped (swapping them would be a no-op).
+
 ## [0.3.0.0] - 2026-06-09
 
 ### Added

--- a/sydtest-mutation-plugin/default.nix
+++ b/sydtest-mutation-plugin/default.nix
@@ -6,7 +6,7 @@
 }:
 mkDerivation {
   pname = "sydtest-mutation-plugin";
-  version = "0.3.0.0";
+  version = "0.4.0.0";
   src = ./.;
   libraryHaskellDepends = [
     aeson base bytestring containers directory filepath ghc ghc-boot

--- a/sydtest-mutation-plugin/package.yaml
+++ b/sydtest-mutation-plugin/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest-mutation-plugin
-version: 0.3.0.0
+version: 0.4.0.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Instrument.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Instrument.hs
@@ -14,6 +14,7 @@ module Test.Syd.Mutation.Plugin.Instrument
     runInstrument,
     instrumentModule,
     applySpanRemoval,
+    applySwapSpans,
     parseFunMutationAnns,
     FunMutationAnns (..),
     LocalDisable (..),
@@ -96,6 +97,11 @@ data SrcSpanDelta
     -- @not a || b@), so we replace the whole @OpApp@ span with a prefix-form
     -- rewrite instead.
     ReplaceOuterSpan RealSrcSpan Text
+  | -- | Swap the source text at two sub-spans (both within the matched
+    -- expression's span) with each other, leaving everything else
+    -- untouched.  Used by the 'SwitchFunctionArguments' operator to swap two
+    -- equal-typed arguments of a function application.
+    SwapSpans RealSrcSpan RealSrcSpan
 
 -- ---------------------------------------------------------------------------
 -- Operator
@@ -1168,6 +1174,54 @@ applyDelta allLines outerStart outerEnd colS colE delta spanLines = case delta o
   -- bounds already cover the outer span and 'applyTokenReplace' does the
   -- right thing.
   ReplaceOuterSpan _ newText -> applyTokenReplace colS colE newText spanLines
+  SwapSpans spanX spanY ->
+    applySwapSpans allLines outerStart outerEnd colS colE spanX spanY
+
+-- | Render the matched expression's display span (@outerStart@..@outerEnd@,
+-- columns @colS@..@colE@) with the source text at two sub-spans swapped, and
+-- everything else left intact.
+--
+-- The two sub-spans must lie within the display span and must not overlap.
+-- Like 'applyTokenReplace', a multi-line result is collapsed onto a single
+-- line (intermediate lines joined with single spaces), which is enough for
+-- the manifest preview.  Out-of-range line/column references resolve to
+-- empty text rather than crashing, matching 'applySpanRemoval'.
+applySwapSpans :: [Text] -> Int -> Int -> Int -> Int -> RealSrcSpan -> RealSrcSpan -> [Text]
+applySwapSpans allLines outerStart outerEnd colS colE spanX spanY =
+  let (spanA, spanB) = orderSpans spanX spanY
+      lineAt n = case drop (n - 1) allLines of
+        (l : _) -> l
+        [] -> T.empty
+      slice (l1, c1) (l2, c2)
+        | l1 == l2 = T.take (c2 - c1) (T.drop (c1 - 1) (lineAt l1))
+        | otherwise =
+            let firstPart = T.drop (c1 - 1) (lineAt l1)
+                middleParts = map lineAt [l1 + 1 .. l2 - 1]
+                lastPart = T.take (c2 - 1) (lineAt l2)
+             in T.intercalate " " (firstPart : middleParts ++ [lastPart])
+      aStart = (srcSpanStartLine spanA, srcSpanStartCol spanA)
+      aEnd = (srcSpanEndLine spanA, srcSpanEndCol spanA)
+      bStart = (srcSpanStartLine spanB, srcSpanStartCol spanB)
+      bEnd = (srcSpanEndLine spanB, srcSpanEndCol spanB)
+      -- Everything before the matched expression on its first line, and
+      -- everything after it on its last line, is preserved verbatim.
+      linePrefix = T.take (colS - 1) (lineAt outerStart)
+      lineSuffix = T.drop (colE - 1) (lineAt outerEnd)
+      -- Text from the matched expression's start up to the earlier span,
+      -- the gap between the spans, and the tail after the later span.
+      prefix = slice (outerStart, colS) aStart
+      midText = slice aEnd bStart
+      suffix = slice bEnd (outerEnd, colE)
+      aText = slice aStart aEnd
+      bText = slice bStart bEnd
+   in [linePrefix <> prefix <> bText <> midText <> aText <> suffix <> lineSuffix]
+
+-- | Order two spans so the first one starts no later than the second.
+orderSpans :: RealSrcSpan -> RealSrcSpan -> (RealSrcSpan, RealSrcSpan)
+orderSpans s1 s2 =
+  if (srcSpanStartLine s1, srcSpanStartCol s1) <= (srcSpanStartLine s2, srcSpanStartCol s2)
+    then (s1, s2)
+    else (s2, s1)
 
 -- | Wrap the matched span text with @prefix@ before and @suffix@ after.
 -- For multi-line spans only the prefix lands on the first line and the

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Instrument.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Instrument.hs
@@ -6,6 +6,7 @@
 module Test.Syd.Mutation.Plugin.Instrument
   ( MutationRecord (..),
     MutationOperator (..),
+    MutationAlt (..),
     SrcSpanDelta (..),
     InstrumentEnv (..),
     OpAppCtx (..),
@@ -106,11 +107,34 @@ data SrcSpanDelta
 -- ---------------------------------------------------------------------------
 -- Operator
 
+-- | A single mutation alternative produced by an operator at one site.
+--
+-- An operator returns a list of these (one per distinct mutation to generate
+-- at the site).  Each gets its own 'MutationId' and is wrapped independently
+-- as a nested 'ifMutation' call; 'tryMutateWith' validates each by desugaring
+-- and silently drops any that produce diagnostics (e.g. overflowed literals).
+data MutationAlt = MutationAlt
+  { -- | The result type of the matched expression (used to type the
+    -- @ifMutation@ wrapper).
+    mutAltType :: Type,
+    -- | The mutated replacement expression.
+    mutAltExpr :: LHsExpr GhcTc,
+    -- | Human-readable description of the original code, for the manifest.
+    mutAltOriginal :: String,
+    -- | Human-readable description of the replacement, for the manifest.
+    mutAltReplacement :: String,
+    -- | How the source text changes, for the manifest preview.
+    mutAltDelta :: SrcSpanDelta,
+    -- | Optional hint about how this mutation can be mitigated other than by
+    -- killing it (e.g. that it is an equivalent mutant and which config key
+    -- suppresses it).  'Nothing' for most operators.
+    mutAltMitigation :: Maybe Text
+  }
+
 -- | A single mutation operator.
 --
 -- 'operatorMatch' inspects a type-checked expression and, if it is a candidate
--- for this operator, returns the mutated replacement together with the
--- human-readable original and replacement strings used in the manifest.
+-- for this operator, returns the mutation alternatives to generate at it.
 -- Returning 'Nothing' means "not a candidate".
 --
 -- The matched expression has already been recursively instrumented by the
@@ -122,12 +146,7 @@ data MutationOperator = MutationOperator
     -- | @Just action@ if this expression is a mutation candidate, @Nothing@ otherwise.
     -- The action runs in 'InstrM' so it can look up replacement operator ids via
     -- 'TcM' when needed (e.g. swapping @(+)@ for @(-)@).
-    -- The action returns a list of @(ty, mutated, originalStr, replacementStr, delta)@
-    -- tuples, one per distinct mutation to generate at this site.  Each gets its own
-    -- 'MutationId' and is wrapped independently as a nested 'ifMutation' call.
-    -- 'tryMutateWith' will validate each alternative via desugaring and silently drop
-    -- any that produce diagnostics (e.g. overflowed literals).
-    operatorMatch :: LHsExpr GhcTc -> Maybe (InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)])
+    operatorMatch :: LHsExpr GhcTc -> Maybe (InstrM [MutationAlt])
   }
 
 -- ---------------------------------------------------------------------------
@@ -135,6 +154,12 @@ data MutationOperator = MutationOperator
 
 data InstrumentEnv = InstrumentEnv
   { instrumentEnvModule :: Module,
+    -- | Source name ('OccName' string) of the enclosing top-level binding we
+    -- are currently instrumenting, if any.  Set on entry to each top-level
+    -- 'FunBind' \/ 'VarBind' \/ 'AbsBinds' (but not for nested local bindings,
+    -- which keep the top-level name).  Recorded in each mutation so the report
+    -- can suggest the exact @{-# ANN \<binding\> ... #-}@ disable annotation.
+    instrumentEnvCurrentBinding :: Maybe String,
     -- | The module's 'GlobalRdrEnv', used by operators to look up replacement ids.
     instrumentEnvRdrEnv :: GlobalRdrEnv,
     -- | Id for Test.Syd.Mutation.Runtime.ifMutation, looked up once per module.
@@ -302,6 +327,7 @@ runInstrument tcGblEnv operators annEnv disabledMutations mSrcPath debug skipThS
     runReaderT
     InstrumentEnv
       { instrumentEnvModule = modul,
+        instrumentEnvCurrentBinding = Nothing,
         instrumentEnvRdrEnv = rdrEnv,
         instrumentEnvIfMutationId = ifMutId,
         instrumentEnvMutationIdCon = mutIdCon,
@@ -377,7 +403,7 @@ instrumentBind = \case
     -- 'instrumentEnvInLocalLet' flag is false at module top-level), so it only fires
     -- on truly local bindings.  Inside, 'withFunBindEnv' sees no annotations
     -- (locals can't be ANN'd) and leaves the disable map intact.
-    mg' <- withLocalDisable funName (withFunBindEnv funName (instrumentMatchGroup mg))
+    mg' <- withCurrentBinding funName (withLocalDisable funName (withFunBindEnv funName (instrumentMatchGroup mg)))
     pure (FunBind x name mg')
   PatBind x pat mult rhs -> PatBind x pat mult <$> instrumentGRHSs rhs
   -- Skip evidence bindings.  The typechecker materialises the dictionaries an
@@ -389,7 +415,7 @@ instrumentBind = \case
   -- evidence alone.  User-written @x = e@ bindings are never evidence, so they
   -- are still instrumented.
   b@(VarBind _ var _) | isEvVar var -> pure b
-  VarBind x var rhs -> VarBind x var <$> withLocalDisable (idName var) (instrumentLExpr rhs)
+  VarBind x var rhs -> VarBind x var <$> withCurrentBinding (idName var) (withLocalDisable (idName var) (instrumentLExpr rhs))
   PatSynBind x psb -> pure (PatSynBind x psb)
   -- At GhcTc, XHsBindsLR carries an AbsBinds (see XXHsBindsLR instance).
   -- {-# ANN f #-} annotations attach to the poly Id (abe_poly), but the inner
@@ -399,6 +425,19 @@ instrumentBind = \case
     let polyNames = map (idName . abe_poly) abs_exports
     binds' <- foldr withFunBindEnv (mapBagM (traverse instrumentBind) abs_binds) polyNames
     pure (XHsBindsLR ab {abs_binds = binds'})
+
+-- | Record @name@ as the enclosing top-level binding for the wrapped action,
+-- so mutations inside it carry the binding name for the report's disable-hint.
+--
+-- A no-op once we are inside a local @let@ \/ @where@
+-- ('instrumentEnvInLocalLet' is True): a nested binding keeps the enclosing
+-- top-level name, which is the one a @{-# ANN ... #-}@ would target.
+withCurrentBinding :: Name -> InstrM a -> InstrM a
+withCurrentBinding name action = do
+  inLocal <- asks instrumentEnvInLocalLet
+  if inLocal
+    then action
+    else local (\env -> env {instrumentEnvCurrentBinding = Just (getOccString name)}) action
 
 -- | If @bindName@'s source-level name is a key in 'instrumentEnvLocalDisables',
 -- narrow 'instrumentEnvOperators' for the wrapped action and remove the entry from
@@ -1001,8 +1040,8 @@ applyOperator origExpr fallthrough op = case operatorMatch op origExpr of
 -- Any test built with @-Werror=incomplete-patterns@ (or that exercises the
 -- runtime @MatchFail@) would kill the mutant anyway, so producing it would
 -- just add noise to the manifest.
-validateAlt :: HscEnv -> (Type, LHsExpr GhcTc, String, String, SrcSpanDelta) -> IO Bool
-validateAlt hscEnv (_, mutated, _, _, _) = do
+validateAlt :: HscEnv -> MutationAlt -> IO Bool
+validateAlt hscEnv MutationAlt {mutAltExpr = mutated} = do
   let dflags' =
         foldl
           wopt_set
@@ -1042,7 +1081,7 @@ containsSpan outer inner =
 -- 3-element list both have replStr "2 elements", and without an index the
 -- 'MutationId's would collide.  The index is appended as the last component
 -- of the id.
-applyAlts :: String -> NonEmpty (Type, LHsExpr GhcTc, String, String, SrcSpanDelta) -> LHsExpr GhcTc -> InstrM (LHsExpr GhcTc)
+applyAlts :: String -> NonEmpty MutationAlt -> LHsExpr GhcTc -> InstrM (LHsExpr GhcTc)
 applyAlts opName alts original = do
   (wrapped, records) <- go 1 alts
   -- Every applyAlts call emits exactly one mutation group, even if a
@@ -1052,12 +1091,12 @@ applyAlts opName alts original = do
   tell [MutationGroup records]
   pure wrapped
   where
-    go altIndex ((ty, mutated, origStr, replStr, delta) :| rest) = do
-      (mid, mRec) <- recordMutation original opName origStr replStr delta altIndex
+    go altIndex (alt :| rest) = do
+      (mid, mRec) <- recordMutation original opName alt altIndex
       (innerExpr, innerRecs) <- case rest of
         [] -> pure (original, [])
         (a : as) -> go (altIndex + 1) (a :| as)
-      outer <- wrapWithIfMutation ty mid mutated innerExpr
+      outer <- wrapWithIfMutation (mutAltType alt) mid (mutAltExpr alt) innerExpr
       let recs = maybe innerRecs (: innerRecs) mRec
       pure (outer, recs)
 
@@ -1068,16 +1107,14 @@ applyAlts opName alts original = do
 recordMutation ::
   LHsExpr GhcTc ->
   String ->
-  String ->
-  String ->
-  SrcSpanDelta ->
+  MutationAlt ->
   -- | 1-based index of this alternative within the operator's match.
   -- Appended to the id so alternatives with identical @replStr@ text do not
   -- collide.
   Int ->
   InstrM (MutationId, Maybe MutationRecord)
-recordMutation le op origStr replStr delta altIndex = do
-  InstrumentEnv {instrumentEnvModule, instrumentEnvSourceFile, instrumentEnvSkipThSplices, instrumentEnvSpliceSpans} <- ask
+recordMutation le op MutationAlt {mutAltOriginal = origStr, mutAltReplacement = replStr, mutAltDelta = delta, mutAltMitigation = mitigation} altIndex = do
+  InstrumentEnv {instrumentEnvModule, instrumentEnvSourceFile, instrumentEnvSkipThSplices, instrumentEnvSpliceSpans, instrumentEnvCurrentBinding} <- ask
   let sp = getLocA le
   case sp of
     RealSrcSpan rss _
@@ -1142,7 +1179,9 @@ recordMutation le op origStr replStr delta altIndex = do
                 mutRecMutatedLines = mutatedLines,
                 mutRecContextBefore = ctxBefore,
                 mutRecContextAfter = ctxAfter,
-                mutRecCoveringTests = Nothing
+                mutRecCoveringTests = Nothing,
+                mutRecBinding = T.pack <$> instrumentEnvCurrentBinding,
+                mutRecMitigation = mitigation
               }
       liftTcM $
         liftIO $ do

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/Arith.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/Arith.hs
@@ -4,8 +4,7 @@ module Test.Syd.Mutation.Plugin.Operator.Arith (theOperator) where
 
 import Control.Monad.Reader (ask)
 import qualified Data.Text as T
-import GHC
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), SrcSpanDelta (..), liftTcM)
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationAlt (..), MutationOperator (..), SrcSpanDelta (..), liftTcM)
 import Test.Syd.Mutation.Plugin.Operator.Util (TcOpApp (..), matchTcOpApp, mkOpReplacement)
 
 theOperator :: MutationOperator
@@ -39,7 +38,7 @@ arithOps = ["+", "-", "*"]
 
 action ::
   TcOpApp ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action TcOpApp {tcOpAppTy, tcOpAppLhs, tcOpAppOp, tcOpAppRhs, tcOpAppOcc, tcOpAppOpSrcSpan} = do
   InstrumentEnv {instrumentEnvRdrEnv} <- ask
   let replacements = filter (/= tcOpAppOcc) arithOps
@@ -49,6 +48,14 @@ action TcOpApp {tcOpAppTy, tcOpAppLhs, tcOpAppOp, tcOpAppRhs, tcOpAppOcc, tcOpAp
   mapM
     ( \replOcc -> do
         repl <- liftTcM $ mkOpReplacement instrumentEnvRdrEnv tcOpAppLhs tcOpAppOp tcOpAppRhs replOcc
-        pure (tcOpAppTy, repl, tcOpAppOcc, replOcc, delta replOcc)
+        pure
+          MutationAlt
+            { mutAltType = tcOpAppTy,
+              mutAltExpr = repl,
+              mutAltOriginal = tcOpAppOcc,
+              mutAltReplacement = replOcc,
+              mutAltDelta = delta replOcc,
+              mutAltMitigation = Nothing
+            }
     )
     replacements

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/BoolLit.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/BoolLit.hs
@@ -6,7 +6,7 @@ import qualified Data.Text as T
 import GHC
 import GHC.Builtin.Types (boolTy, falseDataCon, trueDataCon)
 import GHC.Types.Name (getOccString)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, MutationOperator (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, MutationAlt (..), MutationOperator (..), SrcSpanDelta (..))
 
 theOperator :: MutationOperator
 theOperator =
@@ -32,9 +32,18 @@ boolLits = ["True", "False"]
 
 action ::
   String ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action origOcc =
   let repl = if origOcc == "True" then falseDataCon else trueDataCon
       replOcc = if origOcc == "True" then "False" else "True"
       replExpr = nlHsDataCon repl
-   in pure [(boolTy, replExpr, origOcc, replOcc, TokenReplace (T.pack replOcc))]
+   in pure
+        [ MutationAlt
+            { mutAltType = boolTy,
+              mutAltExpr = replExpr,
+              mutAltOriginal = origOcc,
+              mutAltReplacement = replOcc,
+              mutAltDelta = TokenReplace (T.pack replOcc),
+              mutAltMitigation = Nothing
+            }
+        ]

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/Cmp.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/Cmp.hs
@@ -4,9 +4,8 @@ module Test.Syd.Mutation.Plugin.Operator.Cmp (theOperator) where
 
 import Control.Monad.Reader (ask)
 import qualified Data.Text as T
-import GHC
 import GHC.Builtin.Types (boolTy)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), SrcSpanDelta (..), liftTcM)
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationAlt (..), MutationOperator (..), SrcSpanDelta (..), liftTcM)
 import Test.Syd.Mutation.Plugin.Operator.Util (TcOpApp (..), matchTcOpApp, mkOpReplacement)
 
 theOperator :: MutationOperator
@@ -53,7 +52,7 @@ replacementsFor occ
 action ::
   TcOpApp ->
   [String] ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action TcOpApp {tcOpAppLhs, tcOpAppOp, tcOpAppRhs, tcOpAppOcc, tcOpAppOpSrcSpan} replacements = do
   InstrumentEnv {instrumentEnvRdrEnv} <- ask
   let delta replOcc = case tcOpAppOpSrcSpan of
@@ -62,6 +61,14 @@ action TcOpApp {tcOpAppLhs, tcOpAppOp, tcOpAppRhs, tcOpAppOcc, tcOpAppOpSrcSpan}
   mapM
     ( \replOcc -> do
         repl <- liftTcM $ mkOpReplacement instrumentEnvRdrEnv tcOpAppLhs tcOpAppOp tcOpAppRhs replOcc
-        pure (boolTy, repl, tcOpAppOcc, replOcc, delta replOcc)
+        pure
+          MutationAlt
+            { mutAltType = boolTy,
+              mutAltExpr = repl,
+              mutAltOriginal = tcOpAppOcc,
+              mutAltReplacement = replOcc,
+              mutAltDelta = delta replOcc,
+              mutAltMitigation = Nothing
+            }
     )
     replacements

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ConstBool.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ConstBool.hs
@@ -9,7 +9,7 @@ import qualified Data.Text as T
 import GHC
 import GHC.Builtin.Types (boolTyCon, falseDataCon, trueDataCon)
 import GHC.Types.Name (getOccString)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), OpAppCtx (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationAlt (..), MutationOperator (..), OpAppCtx (..), SrcSpanDelta (..))
 import Test.Syd.Mutation.Plugin.Operator.Util (ConstFnMatch (..), arrowTy, mkConstLambda, prefixFormPreview, viewConstFnResult)
 
 -- | Replace an expression whose type is @arg1 -> ... -> argN -> Bool@
@@ -56,7 +56,7 @@ isBoolLit = \case
 action ::
   LHsExpr GhcTc ->
   ConstFnMatch ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action le ConstFnMatch {cfnArgTys, cfnResTy} = do
   InstrumentEnv {instrumentEnvInGuard, instrumentEnvOpAppCtx, instrumentEnvAppDepth} <- ask
   let arity = length cfnArgTys
@@ -89,7 +89,14 @@ action le ConstFnMatch {cfnArgTys, cfnResTy} = do
                 (origLabel, replLabel) = case cfnArgTys of
                   [] -> ("e", boolName)
                   _ -> ("f", "\\" ++ unwords (replicate arity "_") ++ " -> " ++ boolName)
-             in (wholeTy, mutated, origLabel, replLabel, delta)
+             in MutationAlt
+                  { mutAltType = wholeTy,
+                    mutAltExpr = mutated,
+                    mutAltOriginal = origLabel,
+                    mutAltReplacement = replLabel,
+                    mutAltDelta = delta,
+                    mutAltMitigation = Nothing
+                  }
           trueAlt = mkAlt trueDataCon "True"
           falseAlt = mkAlt falseDataCon "False"
           -- The guard carveout applies only at arity 0; a Bool-typed lambda is

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ConstEmptyList.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ConstEmptyList.hs
@@ -9,7 +9,7 @@ import qualified Data.Text as T
 import GHC
 import GHC.Builtin.Types (charTyCon, listTyCon)
 import GHC.Core.Type (tyConAppTyCon_maybe)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), OpAppCtx (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationAlt (..), MutationOperator (..), OpAppCtx (..), SrcSpanDelta (..))
 import Test.Syd.Mutation.Plugin.Operator.Util (ConstFnMatch (..), arrowTy, mkConstLambda, prefixFormPreview, unwrapWrap, viewConstFnResult)
 import Test.Syd.Mutation.Plugin.OptParse (OperatorConfig (..), operatorExtraFlag)
 
@@ -33,7 +33,7 @@ action ::
   LHsExpr GhcTc ->
   Type ->
   ConstFnMatch ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action le elTy ConstFnMatch {cfnArgTys, cfnResTy} = do
   opAppCtx <- asks instrumentEnvOpAppCtx
   appDepth <- asks instrumentEnvAppDepth
@@ -77,7 +77,16 @@ action le elTy ConstFnMatch {cfnArgTys, cfnResTy} = do
           replLabel = case cfnArgTys of
             [] -> "[]"
             _ -> "\\" ++ unwords (replicate arity "_") ++ " -> []"
-       in pure [(wholeTy, mutated, origLabel, replLabel, delta)]
+       in pure
+            [ MutationAlt
+                { mutAltType = wholeTy,
+                  mutAltExpr = mutated,
+                  mutAltOriginal = origLabel,
+                  mutAltReplacement = replLabel,
+                  mutAltDelta = delta,
+                  mutAltMitigation = Nothing
+                }
+            ]
 
 -- | Whether the list element type is 'Char' (i.e. the list is a
 -- @[Char]@/'String').  Used to honour @skip-strings@.

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ConstNothing.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ConstNothing.hs
@@ -7,7 +7,7 @@ import Control.Monad.Reader (asks)
 import qualified Data.Text as T
 import GHC
 import GHC.Builtin.Types (maybeTyCon, nothingDataCon)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), OpAppCtx (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationAlt (..), MutationOperator (..), OpAppCtx (..), SrcSpanDelta (..))
 import Test.Syd.Mutation.Plugin.Operator.Util (ConstFnMatch (..), arrowTy, mkConstLambda, prefixFormPreview, viewConstFnResult)
 
 -- | Replace an expression whose type is @arg1 -> ... -> argN -> Maybe a@
@@ -39,7 +39,7 @@ theOperator =
 action ::
   LHsExpr GhcTc ->
   ConstFnMatch ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action le ConstFnMatch {cfnArgTys, cfnResTy} = do
   opAppCtx <- asks instrumentEnvOpAppCtx
   appDepth <- asks instrumentEnvAppDepth
@@ -72,4 +72,13 @@ action le ConstFnMatch {cfnArgTys, cfnResTy} = do
           replLabel = case cfnArgTys of
             [] -> "Nothing"
             _ -> "\\" ++ unwords (replicate arity "_") ++ " -> Nothing"
-       in pure [(wholeTy, mutated, origLabel, replLabel, delta)]
+       in pure
+            [ MutationAlt
+                { mutAltType = wholeTy,
+                  mutAltExpr = mutated,
+                  mutAltOriginal = origLabel,
+                  mutAltReplacement = replLabel,
+                  mutAltDelta = delta,
+                  mutAltMitigation = Nothing
+                }
+            ]

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/IntLit.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/IntLit.hs
@@ -5,7 +5,7 @@ module Test.Syd.Mutation.Plugin.Operator.IntLit (theOperator) where
 import qualified Data.Text as T
 import GHC
 import GHC.Types.SourceText (il_value)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, MutationOperator (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, MutationAlt (..), MutationOperator (..), SrcSpanDelta (..))
 import Test.Syd.Mutation.Plugin.Operator.Util (mkIntLitExpr)
 
 theOperator :: MutationOperator
@@ -23,7 +23,19 @@ action ::
   Type ->
   OverLitTc ->
   Integer ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action ty oltc n =
   let candidates = filter (/= n) [0, 1, negate n]
-   in pure $ map (\r -> (ty, mkIntLitExpr r oltc, show n, show r, TokenReplace (T.pack (show r)))) candidates
+   in pure $
+        map
+          ( \r ->
+              MutationAlt
+                { mutAltType = ty,
+                  mutAltExpr = mkIntLitExpr r oltc,
+                  mutAltOriginal = show n,
+                  mutAltReplacement = show r,
+                  mutAltDelta = TokenReplace (T.pack (show r)),
+                  mutAltMitigation = Nothing
+                }
+          )
+          candidates

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ListLit.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ListLit.hs
@@ -4,7 +4,7 @@ module Test.Syd.Mutation.Plugin.Operator.ListLit (theOperator) where
 
 import GHC
 import GHC.Builtin.Types (mkListTy)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, MutationOperator (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, MutationAlt (..), MutationOperator (..), SrcSpanDelta (..))
 
 theOperator :: MutationOperator
 theOperator =
@@ -22,7 +22,7 @@ action ::
   SrcSpanAnnA ->
   Type ->
   [LHsExpr GhcTc] ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action ann elTy es =
   let listTy = mkListTy elTy
       n = length es
@@ -30,12 +30,14 @@ action ann elTy es =
         RealSrcSpan rss _ -> [rss]
         UnhelpfulSpan _ -> []
       mkList xs delta =
-        ( listTy,
-          L ann (ExplicitList elTy xs),
-          show n ++ " elements",
-          show (length xs) ++ " elements",
-          delta
-        )
+        MutationAlt
+          { mutAltType = listTy,
+            mutAltExpr = L ann (ExplicitList elTy xs),
+            mutAltOriginal = show n ++ " elements",
+            mutAltReplacement = show (length xs) ++ " elements",
+            mutAltDelta = delta,
+            mutAltMitigation = Nothing
+          }
       -- Always produce: empty list, drop-head.
       -- Only add drop-last if it gives a different length than drop-head
       -- (i.e. n > 2; when n == 2 both give one element).

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/LogicOp.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/LogicOp.hs
@@ -4,9 +4,8 @@ module Test.Syd.Mutation.Plugin.Operator.LogicOp (theOperator) where
 
 import Control.Monad.Reader (ask)
 import qualified Data.Text as T
-import GHC
 import GHC.Builtin.Types (boolTy)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), SrcSpanDelta (..), liftTcM)
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationAlt (..), MutationOperator (..), SrcSpanDelta (..), liftTcM)
 import Test.Syd.Mutation.Plugin.Operator.Util (TcOpApp (..), matchTcOpApp, mkOpReplacement)
 
 theOperator :: MutationOperator
@@ -26,7 +25,7 @@ logicOps = ["&&", "||"]
 
 action ::
   TcOpApp ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action TcOpApp {tcOpAppLhs, tcOpAppOp, tcOpAppRhs, tcOpAppOcc, tcOpAppOpSrcSpan} = do
   InstrumentEnv {instrumentEnvRdrEnv} <- ask
   let replacements = filter (/= tcOpAppOcc) logicOps
@@ -36,6 +35,14 @@ action TcOpApp {tcOpAppLhs, tcOpAppOp, tcOpAppRhs, tcOpAppOcc, tcOpAppOpSrcSpan}
   mapM
     ( \replOcc -> do
         repl <- liftTcM $ mkOpReplacement instrumentEnvRdrEnv tcOpAppLhs tcOpAppOp tcOpAppRhs replOcc
-        pure (boolTy, repl, tcOpAppOcc, replOcc, delta replOcc)
+        pure
+          MutationAlt
+            { mutAltType = boolTy,
+              mutAltExpr = repl,
+              mutAltOriginal = tcOpAppOcc,
+              mutAltReplacement = replOcc,
+              mutAltDelta = delta replOcc,
+              mutAltMitigation = Nothing
+            }
     )
     replacements

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/MaybeOp.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/MaybeOp.hs
@@ -7,7 +7,7 @@ import GHC
 import GHC.Builtin.Types (nothingDataCon)
 import GHC.Hs.Syn.Type (lhsExprType)
 import GHC.Types.Name (getOccString)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, MutationOperator (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, MutationAlt (..), MutationOperator (..), SrcSpanDelta (..))
 
 theOperator :: MutationOperator
 theOperator =
@@ -35,11 +35,20 @@ funOccName = \case
 
 action ::
   LHsExpr GhcTc ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action le =
   -- lhsExprType gives Maybe a, which is the type for the ifMutation wrapper.
   -- nlHsDataCon for nothingDataCon produces Nothing; the desugarer handles
   -- the polymorphic type instantiation via the surrounding type context.
   let mayTy = lhsExprType le
       nothingExpr = nlHsDataCon nothingDataCon
-   in pure [(mayTy, nothingExpr, "Just e", "Nothing", TokenReplace "Nothing")]
+   in pure
+        [ MutationAlt
+            { mutAltType = mayTy,
+              mutAltExpr = nothingExpr,
+              mutAltOriginal = "Just e",
+              mutAltReplacement = "Nothing",
+              mutAltDelta = TokenReplace "Nothing",
+              mutAltMitigation = Nothing
+            }
+        ]

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/Negate.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/Negate.hs
@@ -13,7 +13,7 @@ import GHC.Tc.Utils.TcType (tcEqType)
 import GHC.Types.Name (getOccString)
 import GHC.Types.Name.Occurrence (lookupOccEnv, mkVarOcc)
 import GHC.Types.Name.Reader (greName)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), SrcSpanDelta (..), liftTcM)
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationAlt (..), MutationOperator (..), SrcSpanDelta (..), liftTcM)
 
 theOperator :: MutationOperator
 theOperator =
@@ -36,7 +36,7 @@ theOperator =
 
 action ::
   LHsExpr GhcTc ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action le = do
   InstrumentEnv {instrumentEnvRdrEnv} <- ask
   notId <- liftTcM $ case lookupOccEnv instrumentEnvRdrEnv (mkVarOcc "not") of
@@ -47,4 +47,13 @@ action le = do
   -- Wrap with parentheses so the rendered @mutated_lines@ keeps the right
   -- precedence: @not n < 0@ reparses as @(not n) < 0@, but the AST mutant
   -- is @not (n < 0)@. The @WrapWithText@ delta produces @not (n < 0)@.
-  pure [(boolTy, negated, "e", "not (e)", WrapWithText "not (" ")")]
+  pure
+    [ MutationAlt
+        { mutAltType = boolTy,
+          mutAltExpr = negated,
+          mutAltOriginal = "e",
+          mutAltReplacement = "not (e)",
+          mutAltDelta = WrapWithText "not (" ")",
+          mutAltMitigation = Nothing
+        }
+    ]

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/RemoveAction.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/RemoveAction.hs
@@ -5,7 +5,7 @@ module Test.Syd.Mutation.Plugin.Operator.RemoveAction (theOperator) where
 import Control.Monad.Reader (asks)
 import GHC
 import GHC.Hs.Syn.Type (lhsExprType)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationAlt (..), MutationOperator (..), SrcSpanDelta (..))
 import Test.Syd.Mutation.Plugin.Operator.Util (opOccName)
 
 -- | Remove one non-binding action from a do block.
@@ -61,7 +61,7 @@ mutateChain ::
   Type ->
   LHsExpr GhcTc ->
   LHsExpr GhcTc ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 mutateChain ty lhs rest = do
   ignore <- asks instrumentEnvIgnore
   let lhsIgnored = case opOccName lhs of
@@ -74,12 +74,14 @@ mutateChain ty lhs rest = do
             RealSrcSpan rss _ -> [rss]
             UnhelpfulSpan _ -> []
        in pure
-            [ ( ty,
-                rest,
-                "a >> rest",
-                "rest",
-                SpanRemoval removedSpan
-              )
+            [ MutationAlt
+                { mutAltType = ty,
+                  mutAltExpr = rest,
+                  mutAltOriginal = "a >> rest",
+                  mutAltReplacement = "rest",
+                  mutAltDelta = SpanRemoval removedSpan,
+                  mutAltMitigation = Nothing
+                }
             ]
 
 -- | Fallback: also support @HsDo@ if it ever shows up unexpanded
@@ -87,7 +89,7 @@ mutateChain ty lhs rest = do
 -- operator was written for that.
 matchRawHsDo ::
   LHsExpr GhcTc ->
-  Maybe (InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)])
+  Maybe (InstrM [MutationAlt])
 matchRawHsDo = \case
   le@(L ann (HsDo x ctx (L lann stmts)))
     | any isRemovableStmt stmts ->
@@ -112,7 +114,7 @@ rawDoAction ::
   SrcSpanAnnL ->
   [ExprLStmt GhcTc] ->
   Type ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 rawDoAction ann x ctx lann stmts ty = do
   -- Do not offer to remove a statement whose head is on the 'ignore' list:
   -- removing @logDebug "x"@ and the like is the noise the ignore filter
@@ -129,10 +131,12 @@ rawDoAction ann x ctx lann stmts ty = do
             removedSpan = case getLocA s of
               RealSrcSpan rss _ -> [rss]
               UnhelpfulSpan _ -> []
-         in ( ty,
-              L ann (HsDo x ctx (L lann stmts')),
-              show n ++ " statements",
-              show (n - 1) ++ " statements (removed #" ++ show (i + 1) ++ ")",
-              SpanRemoval removedSpan
-            )
+         in MutationAlt
+              { mutAltType = ty,
+                mutAltExpr = L ann (HsDo x ctx (L lann stmts')),
+                mutAltOriginal = show n ++ " statements",
+                mutAltReplacement = show (n - 1) ++ " statements (removed #" ++ show (i + 1) ++ ")",
+                mutAltDelta = SpanRemoval removedSpan,
+                mutAltMitigation = Nothing
+              }
   pure [mkMutation i s | (i, s) <- removable]

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/RemoveCase.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/RemoveCase.hs
@@ -4,7 +4,7 @@ module Test.Syd.Mutation.Plugin.Operator.RemoveCase (theOperator) where
 
 import GHC
 import GHC.Hs.Syn.Type (lhsExprType)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, MutationOperator (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, MutationAlt (..), MutationOperator (..), SrcSpanDelta (..))
 
 theOperator :: MutationOperator
 theOperator =
@@ -26,7 +26,7 @@ action ::
   SrcSpanAnnL ->
   [LMatch GhcTc (LHsExpr GhcTc)] ->
   Type ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action ann x scrut mgx lann alts ty =
   let n = length alts
       mkMutation i alt =
@@ -35,10 +35,12 @@ action ann x scrut mgx lann alts ty =
             removedSpan = case getLocA alt of
               RealSrcSpan rss _ -> [rss]
               UnhelpfulSpan _ -> []
-         in ( ty,
-              L ann (HsCase x scrut mg'),
-              show n ++ " alternatives",
-              show (n - 1) ++ " alternatives (removed #" ++ show (i + 1) ++ ")",
-              SpanRemoval removedSpan
-            )
+         in MutationAlt
+              { mutAltType = ty,
+                mutAltExpr = L ann (HsCase x scrut mg'),
+                mutAltOriginal = show n ++ " alternatives",
+                mutAltReplacement = show (n - 1) ++ " alternatives (removed #" ++ show (i + 1) ++ ")",
+                mutAltDelta = SpanRemoval removedSpan,
+                mutAltMitigation = Nothing
+              }
    in pure [mkMutation i alt | (i, alt) <- zip [0 ..] alts]

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/SwitchFunctionArguments.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/SwitchFunctionArguments.hs
@@ -11,7 +11,7 @@ import GHC.Core.TyCo.Compare (eqType)
 import GHC.Hs.Syn.Type (lhsExprType)
 import GHC.Types.Id (idName)
 import GHC.Types.Name (getOccString, nameModule_maybe)
-import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationAlt (..), MutationOperator (..), SrcSpanDelta (..))
 import Test.Syd.Mutation.Plugin.OptParse (OperatorConfig (..), operatorExtraStrings)
 
 -- | Swap two arguments of the same type in a prefix function application.
@@ -66,7 +66,7 @@ action ::
   LHsExpr GhcTc ->
   [LHsExpr GhcTc] ->
   [(Int, Int)] ->
-  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+  InstrM [MutationAlt]
 action le headExpr args pairs = do
   -- Only fire on the outermost application spine.  Inside @f a b@, the
   -- function side @f a@ is visited with depth >= 1; emitting a swap there
@@ -86,13 +86,19 @@ action le headExpr args pairs = do
     else
       let ty = lhsExprType le
           haveSrc = not (null srcLines)
+          -- Hint shown for any surviving swap: if the called function is
+          -- symmetric the mutant is equivalent and unkillable, and listing the
+          -- function under 'skip-calls-to' suppresses it.
+          mitigation = mitigationFor headExpr
        in pure
-            [ ( ty,
-                foldl mkHsApp headExpr (swapAt i j argI argJ args),
-                origStr,
-                replStr,
-                SwapSpans spanI spanJ
-              )
+            [ MutationAlt
+                { mutAltType = ty,
+                  mutAltExpr = foldl mkHsApp headExpr (swapAt i j argI argJ args),
+                  mutAltOriginal = origStr,
+                  mutAltReplacement = replStr,
+                  mutAltDelta = SwapSpans spanI spanJ,
+                  mutAltMitigation = mitigation
+                }
             | (i, j) <- pairs,
               Just argI <- [indexArg args i],
               Just argJ <- [indexArg args j],
@@ -131,6 +137,26 @@ collectApp = go []
     go acc le = case unLoc le of
       HsApp _ f a -> go (a : acc) f
       _ -> (le, acc)
+
+-- | The mitigation hint recorded on every swap mutation at a call: if the
+-- called function turns out to be symmetric in these arguments the mutant is
+-- equivalent (unkillable), and listing the function under @skip-calls-to@
+-- suppresses it.  'Nothing' when the head is not a named function (so there is
+-- no name to suggest), e.g. a data constructor.
+mitigationFor :: LHsExpr GhcTc -> Maybe Text
+mitigationFor headExpr = do
+  n <- headFunctionName headExpr
+  let fn = getOccString n
+  pure $
+    T.pack $
+      concat
+        [ "If `",
+          fn,
+          "` is symmetric in these arguments this is an equivalent mutant ",
+          "that no test can kill; add `",
+          fn,
+          "` to this operator's `skip-calls-to` config to suppress it."
+        ]
 
 -- | The 'Name' of the function (or constructor) at the head of an
 -- application, peeling the type- and dictionary-application wrappers the

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/SwitchFunctionArguments.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/SwitchFunctionArguments.hs
@@ -3,12 +3,16 @@
 module Test.Syd.Mutation.Plugin.Operator.SwitchFunctionArguments (theOperator) where
 
 import Control.Monad.Reader (asks)
+import qualified Data.Map as Map
 import Data.Text (Text)
 import qualified Data.Text as T
 import GHC
 import GHC.Core.TyCo.Compare (eqType)
 import GHC.Hs.Syn.Type (lhsExprType)
+import GHC.Types.Id (idName)
+import GHC.Types.Name (getOccString, nameModule_maybe)
 import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), SrcSpanDelta (..))
+import Test.Syd.Mutation.Plugin.OptParse (OperatorConfig (..), operatorExtraStrings)
 
 -- | Swap two arguments of the same type in a prefix function application.
 --
@@ -29,6 +33,22 @@ import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), Mutation
 --     swap the full spine already covers.
 --   * Pairs whose two arguments have identical source text are skipped:
 --     swapping them produces an identical program and an unkillable mutant.
+--
+-- Symmetric functions (@max@, @min@, set union, a majority predicate, ...)
+-- produce /equivalent/ mutants — swapping their arguments cannot change the
+-- result, so no test can ever kill the mutant.  Because symmetry is a
+-- semantic property the plugin cannot detect, calls to such functions are
+-- suppressed by listing the function's name under the operator's
+-- @skip-calls-to@ config key:
+--
+-- > operators:
+-- >   SwitchFunctionArguments:
+-- >     skip-calls-to:
+-- >       - max
+-- >       - Data.Set.union
+--
+-- A name matches either bare (@max@, matching any module) or fully qualified
+-- (@GHC.Base.max@).
 theOperator :: MutationOperator
 theOperator =
   MutationOperator
@@ -53,7 +73,15 @@ action le headExpr args pairs = do
   -- would duplicate one the full spine already produces.
   appDepth <- asks instrumentEnvAppDepth
   srcLines <- asks (maybe [] snd . instrumentEnvSourceFile)
-  if appDepth /= 0
+  -- Suppress calls to functions the user has marked symmetric (their swaps
+  -- are equivalent, unkillable mutants).  See this module's haddock.
+  opsConfig <- asks instrumentEnvOperatorsConfig
+  let extra = maybe Map.empty operatorConfigExtra (Map.lookup "SwitchFunctionArguments" opsConfig)
+      skipCallsTo = operatorExtraStrings "skip-calls-to" extra
+      skipThisCall = case headFunctionName headExpr of
+        Just n -> any (`elem` skipCallsTo) (nameMatchCandidates n)
+        Nothing -> False
+  if appDepth /= 0 || skipThisCall
     then pure []
     else
       let ty = lhsExprType le
@@ -103,6 +131,30 @@ collectApp = go []
     go acc le = case unLoc le of
       HsApp _ f a -> go (a : acc) f
       _ -> (le, acc)
+
+-- | The 'Name' of the function (or constructor) at the head of an
+-- application, peeling the type- and dictionary-application wrappers the
+-- typechecker leaves around the 'HsVar'.  'Nothing' for heads that are not a
+-- plain variable (e.g. a lambda or a data constructor at 'ConLikeTc').
+headFunctionName :: LHsExpr GhcTc -> Maybe Name
+headFunctionName = go
+  where
+    go le = case unLoc le of
+      HsVar _ (L _ v) -> Just (idName v)
+      XExpr (WrapExpr (HsWrap _ e)) -> go (noLocA e)
+      HsAppType _ f _ -> go f
+      HsPar _ e -> go e
+      _ -> Nothing
+
+-- | The strings a @skip-calls-to@ entry may use to refer to a name: the bare
+-- occurrence (@max@) and, when the name has a defining module, the fully
+-- qualified form (@GHC.Base.max@).
+nameMatchCandidates :: Name -> [Text]
+nameMatchCandidates n =
+  let occ = T.pack (getOccString n)
+   in case nameModule_maybe n of
+        Just m -> [occ, T.pack (moduleNameString (moduleName m)) <> "." <> occ]
+        Nothing -> [occ]
 
 -- | Indices @(i, j)@ with @i < j@ whose arguments have the same type.
 sameTypePairs :: [LHsExpr GhcTc] -> [(Int, Int)]

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/SwitchFunctionArguments.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/SwitchFunctionArguments.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Syd.Mutation.Plugin.Operator.SwitchFunctionArguments (theOperator) where
+
+import Control.Monad.Reader (asks)
+import Data.Text (Text)
+import qualified Data.Text as T
+import GHC
+import GHC.Core.TyCo.Compare (eqType)
+import GHC.Hs.Syn.Type (lhsExprType)
+import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationOperator (..), SrcSpanDelta (..))
+
+-- | Swap two arguments of the same type in a prefix function application.
+--
+-- When a function (or data constructor) is applied to two value arguments
+-- that have the same type, the call still type-checks with those two
+-- arguments swapped, but usually computes something different.  For every
+-- pair of equal-typed arguments at an application site we emit one mutant
+-- that swaps that pair.
+--
+-- Only prefix applications (@f a b@, @Con a b@) are considered: infix
+-- operator applications are left to their own operators (e.g. 'Arith').  Two
+-- restrictions keep the output honest:
+--
+--   * The operator only fires on the maximal application spine (it skips
+--     sites that are themselves the function side of an enclosing
+--     application, detected via 'instrumentEnvAppDepth').  Without this, the
+--     curried sub-application @f a@ inside @f a b@ would re-emit the same
+--     swap the full spine already covers.
+--   * Pairs whose two arguments have identical source text are skipped:
+--     swapping them produces an identical program and an unkillable mutant.
+theOperator :: MutationOperator
+theOperator =
+  MutationOperator
+    { operatorName = "SwitchFunctionArguments",
+      operatorDescription = "Swap two same-typed arguments of a function application",
+      operatorMatch = \le -> case collectApp le of
+        (headExpr, args)
+          | pairs@(_ : _) <- sameTypePairs args ->
+              Just (action le headExpr args pairs)
+        _ -> Nothing
+    }
+
+action ::
+  LHsExpr GhcTc ->
+  LHsExpr GhcTc ->
+  [LHsExpr GhcTc] ->
+  [(Int, Int)] ->
+  InstrM [(Type, LHsExpr GhcTc, String, String, SrcSpanDelta)]
+action le headExpr args pairs = do
+  -- Only fire on the outermost application spine.  Inside @f a b@, the
+  -- function side @f a@ is visited with depth >= 1; emitting a swap there
+  -- would duplicate one the full spine already produces.
+  appDepth <- asks instrumentEnvAppDepth
+  srcLines <- asks (maybe [] snd . instrumentEnvSourceFile)
+  if appDepth /= 0
+    then pure []
+    else
+      let ty = lhsExprType le
+          haveSrc = not (null srcLines)
+       in pure
+            [ ( ty,
+                foldl mkHsApp headExpr (swapAt i j argI argJ args),
+                origStr,
+                replStr,
+                SwapSpans spanI spanJ
+              )
+            | (i, j) <- pairs,
+              Just argI <- [indexArg args i],
+              Just argJ <- [indexArg args j],
+              RealSrcSpan spanI _ <- [getLocA argI],
+              let textI = spanText srcLines spanI,
+              RealSrcSpan spanJ _ <- [getLocA argJ],
+              let textJ = spanText srcLines spanJ,
+              -- Skip no-op swaps of textually identical arguments.
+              not (haveSrc && textI == textJ),
+              let origStr = label haveSrc i j textI textJ,
+              let replStr = label haveSrc j i textJ textI
+            ]
+  where
+    -- Human-readable manifest summary of the two operands, in the given
+    -- order.  Falls back to positional names when the source isn't available.
+    label haveSrc x y tx ty'
+      | haveSrc = T.unpack tx ++ " " ++ T.unpack ty'
+      | otherwise = "arg" ++ show (x + 1) ++ " " ++ "arg" ++ show (y + 1)
+
+-- | The value arguments of a prefix application, in source order, together
+-- with the function at the head.
+--
+-- The head is returned intact, retaining the type- and dictionary-application
+-- wrappers the typechecker attached to it, so reapplying it to the swapped
+-- arguments stays well-typed.
+--
+-- We deliberately do /not/ peel an enclosing 'HsPar': the parenthesis node
+-- @(f a b)@ and the inner application @f a b@ are visited as separate
+-- expressions by the walker (the walker recurses into an 'HsPar' with
+-- 'instrumentLExpr', which re-runs every operator).  Peeling here would make
+-- the operator fire on both, emitting the same swap twice.  Stopping at the
+-- 'HsPar' means only the inner application produces the mutation.
+collectApp :: LHsExpr GhcTc -> (LHsExpr GhcTc, [LHsExpr GhcTc])
+collectApp = go []
+  where
+    go acc le = case unLoc le of
+      HsApp _ f a -> go (a : acc) f
+      _ -> (le, acc)
+
+-- | Indices @(i, j)@ with @i < j@ whose arguments have the same type.
+sameTypePairs :: [LHsExpr GhcTc] -> [(Int, Int)]
+sameTypePairs args =
+  let typed = zip [0 ..] (map lhsExprType args)
+   in [ (i, j)
+      | (i, ti) <- typed,
+        (j, tj) <- typed,
+        i < j,
+        eqType ti tj
+      ]
+
+-- | Total list indexing without 'Prelude.!!'.
+indexArg :: [a] -> Int -> Maybe a
+indexArg xs i = case drop i xs of
+  (x : _) -> Just x
+  [] -> Nothing
+
+-- | Replace the elements at indices @i@ and @j@ with @xj@ and @xi@.
+swapAt :: Int -> Int -> a -> a -> [a] -> [a]
+swapAt i j xi xj xs =
+  [ if k == i then xj else if k == j then xi else x
+  | (k, x) <- zip [0 ..] xs
+  ]
+
+-- | The exact source text covered by a 'RealSrcSpan'.  Multi-line spans are
+-- joined with single spaces, which is enough for the no-op comparison and the
+-- manifest summary.
+spanText :: [Text] -> RealSrcSpan -> Text
+spanText allLines rss =
+  let startLine = srcSpanStartLine rss
+      endLine = srcSpanEndLine rss
+      colS = srcSpanStartCol rss
+      colE = srcSpanEndCol rss
+      lineN i = case drop (i - 1) allLines of
+        (l : _) -> l
+        [] -> T.empty
+   in if startLine == endLine
+        then T.take (colE - colS) (T.drop (colS - 1) (lineN startLine))
+        else
+          let firstPart = T.drop (colS - 1) (lineN startLine)
+              middleParts = map lineN [startLine + 1 .. endLine - 1]
+              lastPart = T.take (colE - 1) (lineN endLine)
+           in T.intercalate " " (firstPart : middleParts ++ [lastPart])

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operators.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operators.hs
@@ -25,6 +25,7 @@ import qualified Test.Syd.Mutation.Plugin.Operator.MaybeOp
 import qualified Test.Syd.Mutation.Plugin.Operator.Negate
 import qualified Test.Syd.Mutation.Plugin.Operator.RemoveAction
 import qualified Test.Syd.Mutation.Plugin.Operator.RemoveCase
+import qualified Test.Syd.Mutation.Plugin.Operator.SwitchFunctionArguments
 import Test.Syd.Mutation.Plugin.Operators.TH (collectOperators)
 
 allOperators :: [MutationOperator]

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/OptParse.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/OptParse.hs
@@ -9,6 +9,7 @@ module Test.Syd.Mutation.Plugin.OptParse
     OperatorConfig (..),
     operatorsConfigDisabled,
     operatorExtraFlag,
+    operatorExtraStrings,
     defaultSettings,
     parseSettings,
     resolveSettings,
@@ -18,6 +19,7 @@ where
 import Data.Aeson (Object, Value (..))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Foldable (toList)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -101,6 +103,15 @@ operatorExtraFlag :: Text -> Map Text Value -> Bool
 operatorExtraFlag k m = case Map.lookup k m of
   Just (Bool b) -> b
   _ -> False
+
+-- | Read a list-of-strings key from an operator's 'operatorConfigExtra',
+-- defaulting to the empty list.  Accepts a YAML/JSON array of strings; any
+-- non-string elements are ignored.  Used by operators that take a list of
+-- function names (e.g. 'SwitchFunctionArguments' reads @skip-calls-to@).
+operatorExtraStrings :: Text -> Map Text Value -> [Text]
+operatorExtraStrings k m = case Map.lookup k m of
+  Just (Array arr) -> [t | String t <- toList arr]
+  _ -> []
 
 -- | Decode the raw @operators@ config object into a per-operator map.
 decodeOperatorsConfig :: Object -> Map Text OperatorConfig

--- a/sydtest-mutation-plugin/sydtest-mutation-plugin.cabal
+++ b/sydtest-mutation-plugin/sydtest-mutation-plugin.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest-mutation-plugin
-version:        0.3.0.0
+version:        0.4.0.0
 category:       Testing
 homepage:       https://github.com/NorfairKing/sydtest#readme
 bug-reports:    https://github.com/NorfairKing/sydtest/issues
@@ -38,6 +38,7 @@ library
       Test.Syd.Mutation.Plugin.Operator.Negate
       Test.Syd.Mutation.Plugin.Operator.RemoveAction
       Test.Syd.Mutation.Plugin.Operator.RemoveCase
+      Test.Syd.Mutation.Plugin.Operator.SwitchFunctionArguments
       Test.Syd.Mutation.Plugin.Operator.Util
       Test.Syd.Mutation.Plugin.Operators
       Test.Syd.Mutation.Plugin.Operators.TH

--- a/sydtest-mutation-plugin/test/Test/Syd/Mutation/Plugin/InstrumentSpec.hs
+++ b/sydtest-mutation-plugin/test/Test/Syd/Mutation/Plugin/InstrumentSpec.hs
@@ -174,3 +174,51 @@ spec = do
         5
         [mkSpan 2 1 2 2, mkSpan 4 1 4 2]
         `shouldBe` ["a", "c", "e"]
+
+  describe "applySwapSpans" $ do
+    it "swaps two single-line arguments of a prefix application" $
+      -- "foo aaa bbb", swapping "aaa" (cols 5-8) and "bbb" (cols 9-12).
+      applySwapSpans
+        ["foo aaa bbb"]
+        1
+        1
+        1
+        12
+        (mkSpan 1 5 1 8)
+        (mkSpan 1 9 1 12)
+        `shouldBe` ["foo bbb aaa"]
+
+    it "swaps regardless of the order the spans are given in" $
+      applySwapSpans
+        ["foo aaa bbb"]
+        1
+        1
+        1
+        12
+        (mkSpan 1 9 1 12)
+        (mkSpan 1 5 1 8)
+        `shouldBe` ["foo bbb aaa"]
+
+    it "preserves text before and after the matched expression" $
+      -- "  r = foo aaa bbb", the application spans cols 7-18.
+      applySwapSpans
+        ["  r = foo aaa bbb"]
+        1
+        1
+        7
+        18
+        (mkSpan 1 11 1 14)
+        (mkSpan 1 15 1 18)
+        `shouldBe` ["  r = foo bbb aaa"]
+
+    it "keeps a non-swapped middle argument in place" $
+      -- "f aa bb cc", swapping the outer two ("aa" cols 3-5, "cc" cols 9-11).
+      applySwapSpans
+        ["f aa bb cc"]
+        1
+        1
+        1
+        11
+        (mkSpan 1 3 1 5)
+        (mkSpan 1 9 1 11)
+        `shouldBe` ["f cc bb aa"]

--- a/sydtest-mutation-plugin/test/Test/Syd/Mutation/Plugin/OptParseSpec.hs
+++ b/sydtest-mutation-plugin/test/Test/Syd/Mutation/Plugin/OptParseSpec.hs
@@ -80,3 +80,11 @@ spec = describe "Settings parser" $ do
     operatorsConfigDisabled expectedOperators `shouldBe` ["Arith"]
     operatorExtraFlag "skip-strings" (operatorConfigExtra (expectedOperators Map.! "ConstEmptyList"))
       `shouldBe` True
+
+  it "reads a list-of-strings operator key with operatorExtraStrings" $ do
+    let extra = Map.fromList [("skip-calls-to", JSON.toJSON (["max", "min"] :: [String]))]
+    operatorExtraStrings "skip-calls-to" extra `shouldBe` ["max", "min"]
+    -- A missing key and a non-array value both yield the empty list.
+    operatorExtraStrings "absent" extra `shouldBe` []
+    operatorExtraStrings "skip-calls-to" (Map.fromList [("skip-calls-to", JSON.Bool True)])
+      `shouldBe` []

--- a/sydtest-mutation-runtime/src/Test/Syd/Mutation/AugmentedManifest.hs
+++ b/sydtest-mutation-runtime/src/Test/Syd/Mutation/AugmentedManifest.hs
@@ -77,7 +77,13 @@ data AugmentedMutationRecord = AugmentedMutationRecord
     -- | Monotonic-clock timeout (in microseconds) to apply to a mutation child
     -- running this mutation.  Derived during the coverage phase as
     -- @max 30_000_000 (10 * sum baselines_of_covering_tests)@.
-    augmentedMutationRecordTimeoutMicros :: Word
+    augmentedMutationRecordTimeoutMicros :: Word,
+    -- | Source name of the enclosing top-level binding, if known.  Carried
+    -- through from 'mutRecBinding' so the report can suggest the exact
+    -- @{-# ANN \<binding\> ... #-}@ disable annotation.
+    augmentedMutationRecordBinding :: Maybe Text,
+    -- | Optional mitigation hint, carried through from 'mutRecMitigation'.
+    augmentedMutationRecordMitigation :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
   deriving (Aeson.ToJSON, Aeson.FromJSON) via (Autodocodec AugmentedMutationRecord)
@@ -106,6 +112,8 @@ instance HasCodec AugmentedMutationRecord where
         <*> optionalFieldWithDefault' "context_after" [] .= augmentedMutationRecordContextAfter
         <*> optionalFieldWithDefaultWith' "covering_tests" coveringTestsCodec Map.empty .= augmentedMutationRecordCoveringTests
         <*> requiredField' "timeout_micros" .= augmentedMutationRecordTimeoutMicros
+        <*> optionalField' "binding" .= augmentedMutationRecordBinding
+        <*> optionalField' "mitigation" .= augmentedMutationRecordMitigation
 
 instance Validity AugmentedMutationRecord
 
@@ -513,7 +521,7 @@ readMutationRunReport dir = do
 -- | Convert a 'MutationRecord' with coverage data to an 'AugmentedMutationRecord'.
 -- Records with 'mutRecCoveringTests' = 'Nothing' are dropped.
 fromMutationRecord :: MutationRecord -> Maybe AugmentedMutationRecord
-fromMutationRecord MutationRecord {mutRecId, mutRecOperator, mutRecOriginal, mutRecReplacement, mutRecModule, mutRecLine, mutRecEndLine, mutRecColStart, mutRecColEnd, mutRecSourceFile, mutRecSourceLines, mutRecMutatedLines, mutRecContextBefore, mutRecContextAfter, mutRecCoveringTests} =
+fromMutationRecord MutationRecord {mutRecId, mutRecOperator, mutRecOriginal, mutRecReplacement, mutRecModule, mutRecLine, mutRecEndLine, mutRecColStart, mutRecColEnd, mutRecSourceFile, mutRecSourceLines, mutRecMutatedLines, mutRecContextBefore, mutRecContextAfter, mutRecCoveringTests, mutRecBinding, mutRecMitigation} =
   case mutRecCoveringTests of
     Nothing -> Nothing
     Just ts ->
@@ -538,7 +546,9 @@ fromMutationRecord MutationRecord {mutRecId, mutRecOperator, mutRecOriginal, mut
             -- code path constructs the record from a raw MutationRecord
             -- that has no baseline info, so we use the floor as a safe
             -- initial value.
-            augmentedMutationRecordTimeoutMicros = defaultTimeoutMicros
+            augmentedMutationRecordTimeoutMicros = defaultTimeoutMicros,
+            augmentedMutationRecordBinding = mutRecBinding,
+            augmentedMutationRecordMitigation = mutRecMitigation
           }
 
 -- | A mutation that is about to be tested, used as the progress log event.

--- a/sydtest-mutation-runtime/src/Test/Syd/Mutation/Manifest.hs
+++ b/sydtest-mutation-runtime/src/Test/Syd/Mutation/Manifest.hs
@@ -68,7 +68,16 @@ data MutationRecord = MutationRecord
     -- | Tests whose execution reaches this mutation site, keyed by test suite
     -- name.  The empty string @""@ is used for anonymous\/single-suite setups.
     -- 'Nothing' means coverage has not been collected yet.
-    mutRecCoveringTests :: Maybe (Map.Map Text [TestId])
+    mutRecCoveringTests :: Maybe (Map.Map Text [TestId]),
+    -- | Source name ('OccName') of the enclosing top-level binding, if known.
+    -- Used by the report to suggest the exact @{-# ANN \<binding\> ... #-}@
+    -- disable annotation for this mutation.
+    mutRecBinding :: Maybe Text,
+    -- | Optional human-readable hint about how this specific mutation can be
+    -- mitigated other than by killing it (e.g. that it is an equivalent
+    -- mutant and which config key suppresses it).  Set by the operator that
+    -- produced the mutation.
+    mutRecMitigation :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
   deriving (Aeson.ToJSON, Aeson.FromJSON) via (Autodocodec MutationRecord)
@@ -102,6 +111,8 @@ instance HasCodec MutationRecord where
         <*> optionalFieldWithDefault' "context_before" [] .= mutRecContextBefore
         <*> optionalFieldWithDefault' "context_after" [] .= mutRecContextAfter
         <*> optionalFieldWith' "covering_tests" coveringTestsMapCodec .= mutRecCoveringTests
+        <*> optionalField' "binding" .= mutRecBinding
+        <*> optionalField' "mitigation" .= mutRecMitigation
 
 -- | Codec for 'Path Rel File' as a JSON string.
 relFileCodec :: JSONCodec (Path Rel File)

--- a/sydtest-mutation/test/Test/Syd/AugmentedManifestSpec.hs
+++ b/sydtest-mutation/test/Test/Syd/AugmentedManifestSpec.hs
@@ -78,7 +78,9 @@ spec = do
                             ""
                             [ TestId (("add", 0) :| [("adds two numbers", 0)]),
                               TestId (("add", 0) :| [("commutativity", 1)])
-                            ]
+                            ],
+                      mutRecBinding = Nothing,
+                      mutRecMitigation = Nothing
                     }
                 ],
               MutationGroup
@@ -97,7 +99,9 @@ spec = do
                       mutRecMutatedLines = [],
                       mutRecContextBefore = [],
                       mutRecContextAfter = [],
-                      mutRecCoveringTests = Nothing
+                      mutRecCoveringTests = Nothing,
+                      mutRecBinding = Nothing,
+                      mutRecMitigation = Nothing
                     }
                 ]
             ]
@@ -132,7 +136,9 @@ spec = do
                           [ TestId (("add", 0) :| [("adds two numbers", 0)]),
                             TestId (("add", 0) :| [("commutativity", 1)])
                           ],
-                      augmentedMutationRecordTimeoutMicros = 30000000
+                      augmentedMutationRecordTimeoutMicros = 30000000,
+                      augmentedMutationRecordBinding = Nothing,
+                      augmentedMutationRecordMitigation = Nothing
                     }
                 ]
             ]
@@ -167,7 +173,9 @@ spec = do
                       [ TestId (("add", 0) :| [("adds two numbers", 0)]),
                         TestId (("add", 0) :| [("commutativity", 1)])
                       ],
-                  augmentedMutationRecordTimeoutMicros = 30000000
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
                 }
             uncovered =
               AugmentedMutationRecord
@@ -186,7 +194,9 @@ spec = do
                   augmentedMutationRecordContextBefore = [],
                   augmentedMutationRecordContextAfter = [],
                   augmentedMutationRecordCoveringTests = Map.empty,
-                  augmentedMutationRecordTimeoutMicros = 30000000
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
                 }
          in encodePretty
               MutationRunReport

--- a/sydtest-mutation/test/Test/Syd/PhaseBoundarySpec.hs
+++ b/sydtest-mutation/test/Test/Syd/PhaseBoundarySpec.hs
@@ -97,7 +97,9 @@ spec = describe "phase boundary smoke (bug #1)" $ do
                 augmentedMutationRecordContextAfter = [],
                 augmentedMutationRecordCoveringTests =
                   Map.singleton (T.pack ("suite-" ++ show suite)) [],
-                augmentedMutationRecordTimeoutMicros = 30000000
+                augmentedMutationRecordTimeoutMicros = 30000000,
+                augmentedMutationRecordBinding = Nothing,
+                augmentedMutationRecordMitigation = Nothing
               }
           newSuite :: Int -> Int -> AugmentedManifest
           newSuite suite recs =

--- a/sydtest-test/test/Test/Syd/MutationGroupSkipSpec.hs
+++ b/sydtest-test/test/Test/Syd/MutationGroupSkipSpec.hs
@@ -41,7 +41,9 @@ spec = describe "runOneGroup" $ do
               augmentedMutationRecordContextBefore = [],
               augmentedMutationRecordContextAfter = [],
               augmentedMutationRecordCoveringTests = Map.empty,
-              augmentedMutationRecordTimeoutMicros = 30000000
+              augmentedMutationRecordTimeoutMicros = 30000000,
+              augmentedMutationRecordBinding = Nothing,
+              augmentedMutationRecordMitigation = Nothing
             }
         a = mkRec "a"
         b = mkRec "b"
@@ -77,7 +79,9 @@ spec = describe "runOneGroup" $ do
               augmentedMutationRecordContextBefore = [],
               augmentedMutationRecordContextAfter = [],
               augmentedMutationRecordCoveringTests = Map.empty,
-              augmentedMutationRecordTimeoutMicros = 30000000
+              augmentedMutationRecordTimeoutMicros = 30000000,
+              augmentedMutationRecordBinding = Nothing,
+              augmentedMutationRecordMitigation = Nothing
             }
         a = mkRec "a"
         b = mkRec "b"
@@ -133,7 +137,9 @@ spec = describe "runOneGroup" $ do
               augmentedMutationRecordContextBefore = [],
               augmentedMutationRecordContextAfter = [],
               augmentedMutationRecordCoveringTests = Map.empty,
-              augmentedMutationRecordTimeoutMicros = 30000000
+              augmentedMutationRecordTimeoutMicros = 30000000,
+              augmentedMutationRecordBinding = Nothing,
+              augmentedMutationRecordMitigation = Nothing
             }
         a = mkRec "a"
         b = mkRec "b"
@@ -177,7 +183,9 @@ spec = describe "runOneGroup" $ do
               augmentedMutationRecordContextBefore = [],
               augmentedMutationRecordContextAfter = [],
               augmentedMutationRecordCoveringTests = Map.empty,
-              augmentedMutationRecordTimeoutMicros = 30000000
+              augmentedMutationRecordTimeoutMicros = 30000000,
+              augmentedMutationRecordBinding = Nothing,
+              augmentedMutationRecordMitigation = Nothing
             }
         a = mkRec "a"
         b = mkRec "b"
@@ -231,7 +239,9 @@ spec = describe "runOneGroup" $ do
               augmentedMutationRecordContextBefore = [],
               augmentedMutationRecordContextAfter = [],
               augmentedMutationRecordCoveringTests = Map.empty,
-              augmentedMutationRecordTimeoutMicros = 30000000
+              augmentedMutationRecordTimeoutMicros = 30000000,
+              augmentedMutationRecordBinding = Nothing,
+              augmentedMutationRecordMitigation = Nothing
             }
         a = mkRec "a"
         b = mkRec "b"

--- a/sydtest-test/test/Test/Syd/MutationModeSpec.hs
+++ b/sydtest-test/test/Test/Syd/MutationModeSpec.hs
@@ -39,7 +39,9 @@ spec = do
                   augmentedMutationRecordContextBefore = [],
                   augmentedMutationRecordContextAfter = [],
                   augmentedMutationRecordCoveringTests = Map.empty,
-                  augmentedMutationRecordTimeoutMicros = 30000000
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
                 }
             rendered = unlines (map (T.unpack . renderChunksText WithoutColours) (formatMutationLog (MutationId ["only-two", "parts"]) aRecord))
         rendered `shouldBe` "only-two/parts\n"
@@ -61,7 +63,9 @@ spec = do
                   augmentedMutationRecordContextBefore = [],
                   augmentedMutationRecordContextAfter = [],
                   augmentedMutationRecordCoveringTests = Map.empty,
-                  augmentedMutationRecordTimeoutMicros = 30000000
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
                 }
             rendered = unlines (map (T.unpack . renderChunksText WithoutColours) (formatMutationLog (MutationId ["a", "b", "c"]) aRecord))
         rendered `shouldBe` "a/b/c\n"
@@ -83,7 +87,9 @@ spec = do
                   augmentedMutationRecordContextBefore = [],
                   augmentedMutationRecordContextAfter = [],
                   augmentedMutationRecordCoveringTests = Map.empty,
-                  augmentedMutationRecordTimeoutMicros = 30000000
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
                 }
             rendered = unlines (map (T.unpack . renderChunksText WithoutColours) (formatMutationLog (MutationId ["a", "b", "c", "d"]) aRecord))
         rendered `shouldBe` "a/b/c/d\n"
@@ -107,7 +113,9 @@ spec = do
                   augmentedMutationRecordContextBefore = [],
                   augmentedMutationRecordContextAfter = [],
                   augmentedMutationRecordCoveringTests = Map.empty,
-                  augmentedMutationRecordTimeoutMicros = 30000000
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
                 }
             rendered = unlines (map (T.unpack . renderChunksText WithoutColours) (formatMutationLog (MutationId ["Foo.Bar", "ArithOp", "42", "10", "12", "extra"]) record))
         rendered
@@ -136,7 +144,9 @@ spec = do
                   augmentedMutationRecordContextBefore = [],
                   augmentedMutationRecordContextAfter = [],
                   augmentedMutationRecordCoveringTests = Map.empty,
-                  augmentedMutationRecordTimeoutMicros = 30000000
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
                 }
             rendered = unlines (map (T.unpack . renderChunksText WithoutColours) (formatMutationLog (MutationId ["Foo.Bar", "ArithOp", "42", "10", "12", "replStr", "2", "trailing"]) record))
         rendered
@@ -165,7 +175,9 @@ spec = do
                   augmentedMutationRecordContextBefore = [],
                   augmentedMutationRecordContextAfter = [],
                   augmentedMutationRecordCoveringTests = Map.empty,
-                  augmentedMutationRecordTimeoutMicros = 30000000
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
                 }
             rendered = unlines (map (T.unpack . renderChunksText WithoutColours) (formatMutationLog (MutationId ["Foo.Bar", "ArithOp", "42", "10", "12"]) record))
         rendered
@@ -200,7 +212,9 @@ spec = do
                   augmentedMutationRecordContextBefore = [],
                   augmentedMutationRecordContextAfter = [],
                   augmentedMutationRecordCoveringTests = Map.empty,
-                  augmentedMutationRecordTimeoutMicros = 30000000
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
                 }
             rendered = unlines (map (T.unpack . renderChunksText WithoutColours) (formatMutationLog (MutationId ["Foo.Bar", "ListLit", "19", "29", "38", "2 elements", "2"]) record))
         rendered
@@ -228,7 +242,9 @@ spec = do
                   augmentedMutationRecordContextBefore = [],
                   augmentedMutationRecordContextAfter = [],
                   augmentedMutationRecordCoveringTests = Map.empty,
-                  augmentedMutationRecordTimeoutMicros = 30000000
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
                 }
             firstId = MutationId ["Foo.Bar", "ListLit", "19", "29", "38", "2 elements", "1"]
             secondId = MutationId ["Foo.Bar", "ListLit", "19", "29", "38", "2 elements", "2"]
@@ -265,7 +281,9 @@ spec = do
                         [ "  in result"
                         ],
                       augmentedMutationRecordCoveringTests = Map.empty,
-                      augmentedMutationRecordTimeoutMicros = 30000000
+                      augmentedMutationRecordTimeoutMicros = 30000000,
+                      augmentedMutationRecordBinding = Nothing,
+                      augmentedMutationRecordMitigation = Nothing
                     }
 
   describe "renderUnifiedDiff" $ do

--- a/sydtest/CHANGELOG.md
+++ b/sydtest/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.26.1.0] - 2026-06-17
+
+### Added
+
+* The mutation run report now prints, under each surviving mutation, the
+  exact disable annotation for it (using the mutation's operator and enclosing
+  binding) and any mitigation hint the operator attached to it.  Exposed as
+  `survivorMitigationLines` from `Test.Syd.MutationMode`.
+
 ## [0.26.0.0] - 2026-06-09
 
 ### Changed

--- a/sydtest/default.nix
+++ b/sydtest/default.nix
@@ -7,7 +7,7 @@
 }:
 mkDerivation {
   pname = "sydtest";
-  version = "0.26.0.0";
+  version = "0.26.1.0";
   src = ./.;
   libraryHaskellDepends = [
     async autodocodec base bytestring containers deepseq dlist

--- a/sydtest/package.yaml
+++ b/sydtest/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest
-version: 0.26.0.0
+version: 0.26.1.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest/src/Test/Syd/MutationMode/Common.hs
+++ b/sydtest/src/Test/Syd/MutationMode/Common.hs
@@ -379,7 +379,11 @@ renderMutationRunReport
           [chunk "     or for the whole module:"],
           [chunk "       {-# ANN module (\"DisableMutations\" :: String) #-}"],
           [chunk "     or globally in the plugin config (sydtest-mutation-plugin.yaml):"],
-          [chunk "       disabled-mutations: [<Operator>]"]
+          [chunk "       disabled-mutations: [<Operator>]"],
+          [chunk "  3. Suppress an equivalent mutant: if the operator swapped the arguments of a"],
+          [chunk "     symmetric function (SwitchFunctionArguments on e.g. max or set union), no test"],
+          [chunk "     can kill it.  List the function under the operator's skip-calls-to config key:"],
+          [chunk "       operators: {SwitchFunctionArguments: {skip-calls-to: [<function>]}}"]
         ]
       remediationUncoveredBody =
         [ [chunk "  1. Cover it: add a test that exercises the mutation site so the coverage phase records a covering test."],

--- a/sydtest/src/Test/Syd/MutationMode/Common.hs
+++ b/sydtest/src/Test/Syd/MutationMode/Common.hs
@@ -32,6 +32,7 @@ module Test.Syd.MutationMode.Common
     renderMutationProgressEvent,
     renderUnifiedDiff,
     formatMutationLog,
+    survivorMitigationLines,
 
     -- * Coverage progress events
     CoverageProgressEvent (..),
@@ -339,7 +340,7 @@ renderMutationRunReport
       renderSurvivor sm =
         let rec = survivedMutationRecord sm
             mid = augmentedMutationRecordId rec
-         in [] : formatMutationLog mid rec
+         in ([] : formatMutationLog mid rec) ++ survivorMitigationLines rec
       renderTimedOut tm =
         let rec = timedOutMutationRecord tm
             mid = augmentedMutationRecordId rec
@@ -379,11 +380,7 @@ renderMutationRunReport
           [chunk "     or for the whole module:"],
           [chunk "       {-# ANN module (\"DisableMutations\" :: String) #-}"],
           [chunk "     or globally in the plugin config (sydtest-mutation-plugin.yaml):"],
-          [chunk "       disabled-mutations: [<Operator>]"],
-          [chunk "  3. Suppress an equivalent mutant: if the operator swapped the arguments of a"],
-          [chunk "     symmetric function (SwitchFunctionArguments on e.g. max or set union), no test"],
-          [chunk "     can kill it.  List the function under the operator's skip-calls-to config key:"],
-          [chunk "       operators: {SwitchFunctionArguments: {skip-calls-to: [<function>]}}"]
+          [chunk "       disabled-mutations: [<Operator>]"]
         ]
       remediationUncoveredBody =
         [ [chunk "  1. Cover it: add a test that exercises the mutation site so the coverage phase records a covering test."],
@@ -472,6 +469,28 @@ emitCoverageEvent settings ev =
     (settingTerminalCapabilities settings)
     stderr
     (unlinesChunks (renderCoverageProgressEvent ev))
+
+-- | Per-survivor mitigation guidance, appended under a surviving mutation in
+-- the report: the exact disable annotation for this mutation (using its
+-- operator and, when known, its enclosing binding) and any mitigation hint the
+-- operator attached (e.g. an equivalent-mutant suppression).
+survivorMitigationLines :: AugmentedMutationRecord -> [[Chunk]]
+survivorMitigationLines rec = disableLine : mitigationLines
+  where
+    op = augmentedMutationRecordOperator rec
+    disableLine = case augmentedMutationRecordBinding rec of
+      Just b ->
+        [ chunk "  disable: ",
+          fore yellow (chunk (T.pack (concat ["{-# ANN ", T.unpack b, " (\"DisableMutation: ", T.unpack op, "\" :: String) #-}"])))
+        ]
+      Nothing ->
+        [ chunk "  disable: add ",
+          fore yellow (chunk op),
+          chunk " to disabled-mutations in the plugin config"
+        ]
+    mitigationLines = case augmentedMutationRecordMitigation rec of
+      Nothing -> []
+      Just m -> [[chunk "  mitigation: ", chunk m]]
 
 formatMutationLog :: MutationId -> AugmentedMutationRecord -> [[Chunk]]
 formatMutationLog (MutationId parts) AugmentedMutationRecord {augmentedMutationRecordOperator, augmentedMutationRecordOriginal, augmentedMutationRecordReplacement, augmentedMutationRecordSourceLines, augmentedMutationRecordMutatedLines, augmentedMutationRecordSourceFile, augmentedMutationRecordLine, augmentedMutationRecordContextBefore, augmentedMutationRecordContextAfter} =

--- a/sydtest/sydtest.cabal
+++ b/sydtest/sydtest.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest
-version:        0.26.0.0
+version:        0.26.1.0
 synopsis:       A modern testing framework for Haskell with good defaults and advanced testing features.
 description:    A modern testing framework for Haskell with good defaults and advanced testing features. Sydtest aims to make the common easy and the hard possible. See https://github.com/NorfairKing/sydtest#readme for more information.
 category:       Testing


### PR DESCRIPTION
## What

Adds a new mutation operator, **`SwitchFunctionArguments`**: at a prefix function (or data-constructor) application, for every pair of value arguments that have the *same type*, it emits one mutant that swaps those two arguments.

Examples (from the new `Example.SwitchArgsLib`):
- `divideThe a b = div a b` → `div b a` (one mutant)
- `makeColour r g b = RGB r g b` → three mutants: swap (r,g), (r,b), (g,b)
- `greyscale v = RGB v v v` → **no** mutants (every swap is a no-op)

## How

- Runs on the typechecked AST (`GhcTc`), reading each argument's type via `lhsExprType` and comparing with `eqType`. The same-type precondition guarantees the swapped application stays well-typed; the existing desugar-validation pass drops anything that slips through.
- **Maximal-spine only:** gated on `instrumentEnvAppDepth == 0`, so the curried sub-application `f a` inside `f a b` does not re-emit a swap the full spine already covers.
- **No-op skip:** pairs whose arguments have identical source text are dropped (the mutant would be identical to the original and unkillable).
- Rendering: a new `SwapSpans` source delta plus a pure, unit-tested `applySwapSpans` that swaps the two argument substrings in the source preview.

## Tests / feedback loops

- 4 new unit tests for `applySwapSpans` in `InstrumentSpec`.
- New `Example.SwitchArgsLib` + gen spec that kill every swap mutant.
- Disabled the operator on the symmetric `majorityOf5Wrapper` in `ConstFnLib` (its swaps are equivalent, unkillable mutants) and documented the new site on `impliesPair`.
- Golden manifests regenerated.

Validated locally:
- `stack build`/`test sydtest-mutation-plugin` — 34/34 pass
- `nix build .#checks.x86_64-linux.mutation-manifest-example` — PASS
- `nix build .#checks.x86_64-linux.mutation-sydtest-mutation-example` (all-killed) — PASS
- `pre-commit run --all-files` — PASS

Plugin version bumped to `0.4.0.0` with a CHANGELOG entry.