### PR TITLE
Mutation: order covering tests cheapest-first in the mutation child

### DIFF
--- a/sydtest-mutation-driver/CHANGELOG.md
+++ b/sydtest-mutation-driver/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [0.1.0.0] - 2026-07-16
+
+* First released version.

--- a/sydtest-mutation-driver/default.nix
+++ b/sydtest-mutation-driver/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "sydtest-mutation-driver";
-  version = "0.0.0.0";
+  version = "0.1.0.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/sydtest-mutation-driver/package.yaml
+++ b/sydtest-mutation-driver/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest-mutation-driver
-version: 0.0.0.0
+version: 0.1.0.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md
@@ -8,6 +8,9 @@ maintainer: "syd@cs-syd.eu"
 category: Testing
 synopsis: Out-of-process mutation testing driver for sydtest.
 description: Standalone driver executable that orchestrates the coverage and mutation phases of sydtest's mutation testing infrastructure. Spawns instrumented sydtest test suite executables as children.
+
+extra-source-files:
+- CHANGELOG.md
 
 dependencies:
 - base >= 4.7 && < 5

--- a/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver.hs
+++ b/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver.hs
@@ -37,6 +37,7 @@ import Test.Syd.Mutation.AugmentedManifest
     MutationRunReport (..),
     MutationTally (..),
     filterAugmentedManifestByIds,
+    readAndUnionBaselineDirs,
     readAndUnionCoverageDirs,
     writeAugmentedManifestFile,
   )
@@ -49,6 +50,7 @@ import Test.Syd.Mutation.Driver.OptParse
 import Test.Syd.Mutation.Driver.SuitePkg (walkSuitePkgs)
 import Test.Syd.Mutation.Manifest (MutationGroup (..), MutationManifest (..), MutationRecord (..), readManifestDir)
 import Test.Syd.Mutation.Runtime (renderMutationId)
+import Test.Syd.Mutation.TestBaselineMap (writeTestBaselineMapDir)
 
 -- | Top-level entry point: parse the dispatch and run the chosen
 -- subcommand.  The default subcommand is @run@, which runs both mutation
@@ -163,6 +165,10 @@ prepareAugmentedFromCoverageDirs manifestDirs coverageDirs augDir = do
         )
           : map (("  " ++) . renderMutationId) missing
   writeAugmentedManifestFile augDir (filterAugmentedManifestByIds libIds unioned)
+  -- Union the per-test baselines from the same coverage dirs and write them
+  -- next to the assembled manifest, so the mutation child can order covering
+  -- tests cheapest-first.
+  readAndUnionBaselineDirs coverageDirs >>= writeTestBaselineMapDir augDir
 
 -- | Run only the coverage phase: for each suite, run the coverage parent so
 -- the augmented manifest accumulates, then stop.  Writes no report; the

--- a/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/Coverage.hs
+++ b/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/Coverage.hs
@@ -49,7 +49,12 @@ import Test.Syd.Mutation.Manifest
     readManifestDir,
   )
 import Test.Syd.Mutation.Runtime (MutationId)
-import Test.Syd.Mutation.TestBaselineMap (TestBaselineMap (..), readTestBaselineMapFile)
+import Test.Syd.Mutation.TestBaselineMap
+  ( TestBaselineMap (..),
+    readTestBaselineMapDirIfExists,
+    readTestBaselineMapFile,
+    writeTestBaselineMapDir,
+  )
 import Test.Syd.Mutation.TestCoverageMap (TestCoverageMap (..), readTestCoverageMapFile)
 import Test.Syd.Mutation.TestId (TestId, parseTestIdFilterArg, renderTestId)
 import Test.Syd.MutationMode.Common
@@ -99,6 +104,9 @@ runCoverageMode failFast manifestDirs augDir coverageJobs coverageRetry suiteNam
   let writeEmptyAugmented = do
         existing <- readAugmentedManifestFileIfExists augDir
         writeAugmentedManifestFile augDir (fromMaybe (AugmentedManifest []) existing)
+        -- Keep baseline.json present (possibly empty) so the union step and the
+        -- mutation child always find a file to read.
+        mergeBaselineIntoDir mempty
   if all (\(MutationGroup rs) -> null rs) groups
     then do
       emitCoverageEvent (CoverageProgressSkipped CoverageSkipNoMutations)
@@ -135,7 +143,16 @@ runCoverageMode failFast manifestDirs augDir coverageJobs coverageRetry suiteNam
                 Nothing -> newAugmented
                 Just prev -> mergeAugmentedManifests prev newAugmented
           writeAugmentedManifestFile augDir augmented
+          -- Persist the per-test baselines next to the manifest, accumulated
+          -- across suites (slowest time wins), so the mutation child can order
+          -- covering tests cheapest-first.
+          mergeBaselineIntoDir (mconcat baselineMaps)
   where
+    mergeBaselineIntoDir :: TestBaselineMap -> IO ()
+    mergeBaselineIntoDir newBaseline = do
+      existing <- readTestBaselineMapDirIfExists augDir
+      writeTestBaselineMapDir augDir (fromMaybe mempty existing <> newBaseline)
+
     runCoverageChild sem total (i, tid) =
       bracket_ (waitQSem sem) (signalQSem sem) $ do
         emitCoverageEvent $

--- a/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/DiffRun.hs
+++ b/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/DiffRun.hs
@@ -39,6 +39,7 @@ import Test.Syd.Mutation.AugmentedManifest
     MutationRunReport (..),
     SurvivedMutation (..),
     filterAugmentedManifestByIds,
+    readAndUnionBaselineDirs,
     readAndUnionCoverageDirs,
     writeAugmentedManifestFile,
   )
@@ -54,6 +55,7 @@ import Test.Syd.Mutation.Driver.OptParse
     DiffSource (..),
   )
 import Test.Syd.Mutation.Driver.SuitePkg (walkSuitePkgs)
+import Test.Syd.Mutation.TestBaselineMap (writeTestBaselineMapDir)
 import Test.Syd.Mutation.TestId (TestId)
 import Test.Syd.Mutation.TestLocation (TestLocation (..), decodeTestLocations)
 import Test.Syd.MutationMode.Common (formatMutationLog, survivorMitigationLines)
@@ -116,6 +118,9 @@ runDiff DiffSettings {..} = do
   report <-
     withSystemTempDir "mutation-diff-augmented" $ \augDir -> do
       writeAugmentedManifestFile augDir filtered
+      -- Baselines from the same coverage dirs, so the child orders covering
+      -- tests cheapest-first here too.
+      readAndUnionBaselineDirs diffSettingCoverageDirs >>= writeTestBaselineMapDir augDir
       runMutationMode
         diffSettingFailFast
         diffSettingDebug

--- a/sydtest-mutation-driver/sydtest-mutation-driver.cabal
+++ b/sydtest-mutation-driver/sydtest-mutation-driver.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest-mutation-driver
-version:        0.0.0.0
+version:        0.1.0.0
 synopsis:       Out-of-process mutation testing driver for sydtest.
 description:    Standalone driver executable that orchestrates the coverage and mutation phases of sydtest's mutation testing infrastructure. Spawns instrumented sydtest test suite executables as children.
 category:       Testing
@@ -16,6 +16,8 @@ maintainer:     syd@cs-syd.eu
 license:        OtherLicense
 license-file:   LICENSE.md
 build-type:     Simple
+extra-source-files:
+    CHANGELOG.md
 
 source-repository head
   type: git

--- a/sydtest-mutation-runtime/CHANGELOG.md
+++ b/sydtest-mutation-runtime/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [0.1.0.0] - 2026-07-16
+
+* First released version.

--- a/sydtest-mutation-runtime/default.nix
+++ b/sydtest-mutation-runtime/default.nix
@@ -6,7 +6,7 @@
 }:
 mkDerivation {
   pname = "sydtest-mutation-runtime";
-  version = "0.0.0.0";
+  version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
     aeson autodocodec base bytestring containers fast-myers-diff

--- a/sydtest-mutation-runtime/package.yaml
+++ b/sydtest-mutation-runtime/package.yaml
@@ -1,11 +1,14 @@
 name: sydtest-mutation-runtime
-version: 0.0.0.0
+version: 0.1.0.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md
 author: "Tom Sydney Kerckhove"
 maintainer: "syd@cs-syd.eu"
 category: Testing
+
+extra-source-files:
+- CHANGELOG.md
 
 dependencies:
 - base >= 4.7 && < 5

--- a/sydtest-mutation-runtime/src/Test/Syd/Mutation/AugmentedManifest.hs
+++ b/sydtest-mutation-runtime/src/Test/Syd/Mutation/AugmentedManifest.hs
@@ -12,6 +12,7 @@ module Test.Syd.Mutation.AugmentedManifest
     AugmentedManifest (..),
     mergeAugmentedManifests,
     readAndUnionCoverageDirs,
+    readAndUnionBaselineDirs,
     filterAugmentedManifestByIds,
     writeAugmentedManifestFile,
     readAugmentedManifestFile,
@@ -47,6 +48,7 @@ import Data.GenValidity.Path ()
 import Data.GenValidity.Text ()
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -54,6 +56,7 @@ import Path
 import Path.IO (ensureDir, forgivingAbsence)
 import Test.Syd.Mutation.Manifest (MutationRecord (..), relFileCodec)
 import Test.Syd.Mutation.Runtime (MutationId (..))
+import Test.Syd.Mutation.TestBaselineMap (TestBaselineMap, readTestBaselineMapDirIfExists)
 import Test.Syd.Mutation.TestId (TestId)
 
 -- | A mutation record augmented with coverage data.
@@ -290,6 +293,21 @@ readAndUnionCoverageDirs :: [Path Abs Dir] -> IO AugmentedManifest
 readAndUnionCoverageDirs coverageDirs =
   foldl' mergeAugmentedManifests mempty
     <$> mapM (\dir -> readAugmentedManifestFile (dir </> [reldir|augmented|])) coverageDirs
+
+-- | Read and union the per-test baseline timings from the same per-package
+-- coverage directories 'readAndUnionCoverageDirs' consumes.  Each holds an
+-- @augmented/baseline.json@ (absent on older coverage output, treated as empty);
+-- the union merges by taking the slowest recorded time for each test.  Used to
+-- order a mutation child's covering tests cheapest-first.
+--
+-- The slowest-wins merge is 'TestBaselineMap'\'s 'Semigroup', chosen so a
+-- per-mutation timeout is never under-budgeted.  Reusing it here means a test
+-- shared across suites is ordered by its slowest recorded time, which only
+-- affects ordering quality, never which tests run or the verdict.
+readAndUnionBaselineDirs :: [Path Abs Dir] -> IO TestBaselineMap
+readAndUnionBaselineDirs coverageDirs =
+  mconcat . map (fromMaybe mempty)
+    <$> mapM (\dir -> readTestBaselineMapDirIfExists (dir </> [reldir|augmented|])) coverageDirs
 
 -- | O(n) lookup by 'MutationId' across every group.
 lookupAugmentedMutationRecord :: MutationId -> AugmentedManifest -> Maybe AugmentedMutationRecord

--- a/sydtest-mutation-runtime/src/Test/Syd/Mutation/TestBaselineMap.hs
+++ b/sydtest-mutation-runtime/src/Test/Syd/Mutation/TestBaselineMap.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module Test.Syd.Mutation.TestBaselineMap
   ( TestBaselineMap (..),
     readTestBaselineMapFile,
     writeTestBaselineMapFile,
+    writeTestBaselineMapDir,
+    readTestBaselineMapDirIfExists,
   )
 where
 
@@ -17,6 +20,8 @@ import Data.GenValidity
 import Data.GenValidity.Containers ()
 import qualified Data.Map.Strict as Map
 import GHC.Generics (Generic)
+import Path
+import Path.IO (doesFileExist, ensureDir)
 import Test.Syd.Mutation.TestId (TestId)
 
 -- | Per-test monotonic-clock baselines (microseconds) collected during the
@@ -68,3 +73,28 @@ writeTestBaselineMapFile path m =
 readTestBaselineMapFile :: FilePath -> IO (Either String TestBaselineMap)
 readTestBaselineMapFile path =
   eitherDecodeJSONViaCodec . LB.fromStrict <$> SB.readFile path
+
+-- | The name under which a merged 'TestBaselineMap' is stored inside an
+-- augmented-manifest directory, alongside @manifest-augmented.json@.  The
+-- coverage phase writes it and the mutation child reads it to order covering
+-- tests cheapest-first.
+baselineMapRelFile :: Path Rel File
+baselineMapRelFile = [relfile|baseline.json|]
+
+-- | Write a 'TestBaselineMap' to @<dir>/baseline.json@, creating @dir@ if
+-- needed.
+writeTestBaselineMapDir :: Path Abs Dir -> TestBaselineMap -> IO ()
+writeTestBaselineMapDir dir m = do
+  ensureDir dir
+  writeTestBaselineMapFile (fromAbsFile (dir </> baselineMapRelFile)) m
+
+-- | Read @<dir>/baseline.json@, returning 'Nothing' when the file is absent or
+-- unreadable.  Ordering is a best-effort hint, so a missing or corrupt baseline
+-- is not fatal: the caller simply does not reorder.
+readTestBaselineMapDirIfExists :: Path Abs Dir -> IO (Maybe TestBaselineMap)
+readTestBaselineMapDirIfExists dir = do
+  let path = dir </> baselineMapRelFile
+  exists <- doesFileExist path
+  if exists
+    then either (const Nothing) Just <$> readTestBaselineMapFile (fromAbsFile path)
+    else pure Nothing

--- a/sydtest-mutation-runtime/sydtest-mutation-runtime.cabal
+++ b/sydtest-mutation-runtime/sydtest-mutation-runtime.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest-mutation-runtime
-version:        0.0.0.0
+version:        0.1.0.0
 category:       Testing
 homepage:       https://github.com/NorfairKing/sydtest#readme
 bug-reports:    https://github.com/NorfairKing/sydtest/issues
@@ -14,6 +14,8 @@ maintainer:     syd@cs-syd.eu
 license:        OtherLicense
 license-file:   LICENSE.md
 build-type:     Simple
+extra-source-files:
+    CHANGELOG.md
 
 source-repository head
   type: git

--- a/sydtest-mutation/CHANGELOG.md
+++ b/sydtest-mutation/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [0.1.0.0] - 2026-07-16
+
+* First released version.

--- a/sydtest-mutation/default.nix
+++ b/sydtest-mutation/default.nix
@@ -5,7 +5,7 @@
 }:
 mkDerivation {
   pname = "sydtest-mutation";
-  version = "0.0.0.0";
+  version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [ base sydtest sydtest-mutation-runtime ];
   testHaskellDepends = [

--- a/sydtest-mutation/package.yaml
+++ b/sydtest-mutation/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest-mutation
-version: 0.0.0.0
+version: 0.1.0.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md
@@ -8,6 +8,7 @@ maintainer: "syd@cs-syd.eu"
 category: Testing
 
 extra-source-files:
+- CHANGELOG.md
 - test_resources/**/*
 
 dependencies:

--- a/sydtest-mutation/src/Test/Syd/Mutation.hs
+++ b/sydtest-mutation/src/Test/Syd/Mutation.hs
@@ -14,6 +14,8 @@ module Test.Syd.Mutation
     -- * Forest operations
     flattenTestForestWithIds,
     filterTestForestByTrie,
+    reorderTestForestByTiming,
+    reorderForMutationChild,
 
     -- * Running
     execTestDefM',
@@ -27,6 +29,8 @@ import Test.Syd.Mutation.Forest
   ( TestIdTrie (..),
     filterTestForestByTrie,
     flattenTestForestWithIds,
+    reorderForMutationChild,
+    reorderTestForestByTiming,
     testIdTrieFromList,
     testIdTrieFromSet,
   )

--- a/sydtest-mutation/sydtest-mutation.cabal
+++ b/sydtest-mutation/sydtest-mutation.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest-mutation
-version:        0.0.0.0
+version:        0.1.0.0
 category:       Testing
 homepage:       https://github.com/NorfairKing/sydtest#readme
 bug-reports:    https://github.com/NorfairKing/sydtest/issues
@@ -15,6 +15,7 @@ license:        OtherLicense
 license-file:   LICENSE.md
 build-type:     Simple
 extra-source-files:
+    CHANGELOG.md
     test_resources/augmented-manifest.json
     test_resources/legacy-mutation-manifest.json
     test_resources/mutation-manifest.json
@@ -47,6 +48,7 @@ test-suite sydtest-mutation-test
       Test.Syd.MutationIdSpec
       Test.Syd.MutationSpec
       Test.Syd.PhaseBoundarySpec
+      Test.Syd.ReorderSpec
       Test.Syd.TestLocationSpec
       Paths_sydtest_mutation
   hs-source-dirs:

--- a/sydtest-mutation/test/Test/Syd/ReorderSpec.hs
+++ b/sydtest-mutation/test/Test/Syd/ReorderSpec.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Syd.ReorderSpec (spec) where
+
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Test.Syd
+import Test.Syd.Mutation
+import Test.Syd.OptParse (Settings (..), defaultSettings)
+
+spec :: Spec
+spec = describe "reorderTestForestByTiming" $ do
+  it "orders sibling leaves ascending by baseline" $ do
+    forest <-
+      execTestDefM (defaultSettings {settingRandomiseExecutionOrder = False}) $ do
+        it "a" (pure () :: IO ())
+        it "b" (pure () :: IO ())
+        it "c" (pure () :: IO ())
+    let costs =
+          Map.fromList
+            [ (TestId (("a", 0) :| []), 30),
+              (TestId (("b", 0) :| []), 10),
+              (TestId (("c", 0) :| []), 20)
+            ]
+    map (renderTestId . fst) (flattenTestForestWithIds (reorderTestForestByTiming costs forest))
+      `shouldBe` ["b", "c", "a"]
+
+  it "keeps equal-cost and untimed siblings in source order (stable, missing = first)" $ do
+    forest <-
+      execTestDefM (defaultSettings {settingRandomiseExecutionOrder = False}) $ do
+        it "timed-late" (pure () :: IO ())
+        it "untimed" (pure () :: IO ())
+        it "tie1" (pure () :: IO ())
+        it "tie2" (pure () :: IO ())
+    let costs =
+          Map.fromList
+            [ (TestId (("timed-late", 0) :| []), 5),
+              (TestId (("tie1", 0) :| []), 5),
+              (TestId (("tie2", 0) :| []), 5)
+            ]
+    map (renderTestId . fst) (flattenTestForestWithIds (reorderTestForestByTiming costs forest))
+      `shouldBe` ["untimed", "timed-late", "tie1", "tie2"]
+
+  it "reorders a sequential (parallelism) subtree" $ do
+    forest <-
+      execTestDefM (defaultSettings {settingRandomiseExecutionOrder = False}) $
+        sequential $ do
+          it "a" (pure () :: IO ())
+          it "b" (pure () :: IO ())
+          it "c" (pure () :: IO ())
+    let costs =
+          Map.fromList
+            [ (TestId (("a", 0) :| []), 30),
+              (TestId (("b", 0) :| []), 10),
+              (TestId (("c", 0) :| []), 20)
+            ]
+    map (renderTestId . fst) (flattenTestForestWithIds (reorderTestForestByTiming costs forest))
+      `shouldBe` ["b", "c", "a"]
+
+  it "leaves a doNotRandomiseExecutionOrder subtree in source order" $ do
+    forest <-
+      execTestDefM (defaultSettings {settingRandomiseExecutionOrder = False}) $
+        doNotRandomiseExecutionOrder $ do
+          it "z" (pure () :: IO ())
+          it "y" (pure () :: IO ())
+          it "x" (pure () :: IO ())
+    let costs =
+          Map.fromList
+            [ (TestId (("z", 0) :| []), 3),
+              (TestId (("y", 0) :| []), 1),
+              (TestId (("x", 0) :| []), 2)
+            ]
+    map (renderTestId . fst) (flattenTestForestWithIds (reorderTestForestByTiming costs forest))
+      `shouldBe` ["z", "y", "x"]
+
+  it "does not descend into a doNotRandomiseExecutionOrder subtree" $ do
+    forest <-
+      execTestDefM (defaultSettings {settingRandomiseExecutionOrder = False}) $
+        doNotRandomiseExecutionOrder $ do
+          it "z" (pure () :: IO ())
+          randomiseExecutionOrder $ do
+            it "n1" (pure () :: IO ())
+            it "n2" (pure () :: IO ())
+    let costs =
+          Map.fromList
+            [ (TestId (("z", 0) :| []), 30),
+              (TestId (("n1", 0) :| []), 20),
+              (TestId (("n2", 0) :| []), 10)
+            ]
+    map (renderTestId . fst) (flattenTestForestWithIds (reorderTestForestByTiming costs forest))
+      `shouldBe` ["z", "n1", "n2"]
+
+  it "reorders a beforeAll_ group as a unit without splitting its setup" $ do
+    forest <-
+      execTestDefM (defaultSettings {settingRandomiseExecutionOrder = False}) $ do
+        it "outside-mid" (pure () :: IO ())
+        beforeAll_ (pure ()) $ do
+          it "g-cheap" (pure () :: IO ())
+          it "g-expensive" (pure () :: IO ())
+    let costs =
+          Map.fromList
+            [ (TestId (("g-cheap", 0) :| []), 1),
+              (TestId (("g-expensive", 0) :| []), 100),
+              (TestId (("outside-mid", 0) :| []), 50)
+            ]
+    -- Source order is [outside-mid, g-cheap, g-expensive].  A leaf-global sort
+    -- would interleave "outside-mid" (50) between the group's leaves (1, 100).
+    -- Keeping the group as a unit puts it first (min cost 1) and leaves
+    -- "outside-mid" after both of its leaves.
+    map (renderTestId . fst) (flattenTestForestWithIds (reorderTestForestByTiming costs forest))
+      `shouldBe` ["g-cheap", "g-expensive", "outside-mid"]
+
+  it "preserves the set of test ids" $ do
+    forest <-
+      execTestDefM (defaultSettings {settingRandomiseExecutionOrder = False}) $ do
+        describe "g1" $ do
+          it "a" (pure () :: IO ())
+          it "b" (pure () :: IO ())
+        it "c" (pure () :: IO ())
+    let costs = Map.fromList [(TestId (("g1", 0) :| [("a", 0)]), 5)]
+    Set.fromList (map fst (flattenTestForestWithIds (reorderTestForestByTiming costs forest)))
+      `shouldBe` Set.fromList (map fst (flattenTestForestWithIds forest))
+
+  describe "reorderForMutationChild (gate)" $ do
+    it "reorders when randomisation is enabled and a baseline is present" $ do
+      forest <-
+        execTestDefM (defaultSettings {settingRandomiseExecutionOrder = False}) $ do
+          it "a" (pure () :: IO ())
+          it "b" (pure () :: IO ())
+          it "c" (pure () :: IO ())
+      let costs =
+            Map.fromList
+              [ (TestId (("a", 0) :| []), 30),
+                (TestId (("b", 0) :| []), 10),
+                (TestId (("c", 0) :| []), 20)
+              ]
+      map (renderTestId . fst) (flattenTestForestWithIds (reorderForMutationChild True (Just costs) forest))
+        `shouldBe` ["b", "c", "a"]
+
+    it "leaves the forest untouched when randomisation is disabled" $ do
+      forest <-
+        execTestDefM (defaultSettings {settingRandomiseExecutionOrder = False}) $ do
+          it "a" (pure () :: IO ())
+          it "b" (pure () :: IO ())
+          it "c" (pure () :: IO ())
+      let costs =
+            Map.fromList
+              [ (TestId (("a", 0) :| []), 30),
+                (TestId (("b", 0) :| []), 10),
+                (TestId (("c", 0) :| []), 20)
+              ]
+      map (renderTestId . fst) (flattenTestForestWithIds (reorderForMutationChild False (Just costs) forest))
+        `shouldBe` ["a", "b", "c"]
+
+    it "leaves the forest untouched when no baseline is available" $ do
+      forest <-
+        execTestDefM (defaultSettings {settingRandomiseExecutionOrder = False}) $ do
+          it "a" (pure () :: IO ())
+          it "b" (pure () :: IO ())
+          it "c" (pure () :: IO ())
+      map (renderTestId . fst) (flattenTestForestWithIds (reorderForMutationChild True Nothing forest))
+        `shouldBe` ["a", "b", "c"]

--- a/sydtest/CHANGELOG.md
+++ b/sydtest/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.27.2.0] - 2026-07-16
+
+### Changed
+
+* Mutation testing now runs each mutation's covering tests cheapest-first,
+  using the per-test timings measured during the coverage phase.  Because a
+  mutation child runs its covering tests under fail-fast, reaching a failing
+  (killing) test sooner cuts the mutation phase's wall-clock; on two sample
+  projects the mutation phase ran roughly 6% and 24% faster, with identical
+  verdicts.  The ordering is a drop-in alternative to execution-order
+  randomisation: it is applied only when the suite randomises execution order,
+  and it never reorders a `doNotRandomiseExecutionOrder` block, so which tests
+  run (and therefore every mutation verdict) is unchanged.
+
 ## [0.27.1.0] - 2026-06-29
 
 ### Fixed

--- a/sydtest/default.nix
+++ b/sydtest/default.nix
@@ -7,7 +7,7 @@
 }:
 mkDerivation {
   pname = "sydtest";
-  version = "0.27.1.0";
+  version = "0.27.2.0";
   src = ./.;
   libraryHaskellDepends = [
     async autodocodec base bytestring containers deepseq dlist

--- a/sydtest/package.yaml
+++ b/sydtest/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest
-version: 0.27.1.0
+version: 0.27.2.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest/src/Test/Syd/Mutation/Forest.hs
+++ b/sydtest/src/Test/Syd/Mutation/Forest.hs
@@ -16,11 +16,14 @@ module Test.Syd.Mutation.Forest
     flattenTestForestWithIds,
     flattenTestForestWithIdsAndCallStacks,
     filterTestForestByTrie,
+    reorderTestForestByTiming,
+    reorderForMutationChild,
   )
 where
 
 import Control.Monad.State.Strict (State, evalState, gets, modify')
 import Control.Monad.Trans.Writer.CPS (WriterT, execWriterT, tell)
+import Data.List (sortOn)
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -148,6 +151,9 @@ flattenTestForestWith leaf f = evalState (execWriterT (goForest [] f)) Map.empty
         DefFlakinessNode _ sub -> goForest path sub
         DefExpectationNode _ sub -> goForest path sub
 
+    -- [tag:ReorderIdScheme] 'reorderTestForestByTiming' replicates this
+    -- per-description sibling-index assignment so its cost lookups line up with
+    -- the baselines recorded against these ids.
     nextKey :: SpecDefTree outers inner result -> WriterT [(TestId, a)] (State (Map Text Word)) (Maybe (Text, Word))
     nextKey tree = case descriptionOf tree of
       Nothing -> pure Nothing
@@ -254,3 +260,131 @@ filterTestForestByTrie trie = snd . filterForest trie Map.empty
       DefPendingNode t _ -> Just t
       DefDescribeNode t _ -> Just t
       _ -> Nothing
+
+-- | Reorder a 'TestForest' so that, at every sibling level, cheaper tests come
+-- first.  A test's cost is its recorded baseline in the given map; a missing
+-- baseline counts as @0@, so an untimed test runs first.  A subtree is ordered
+-- by the minimum cost of any leaf it contains, so the group most likely to yield
+-- a cheap early kill runs first.
+--
+-- This is a drop-in alternative to execution-order randomisation, legal under
+-- exactly the same conditions.  It mirrors 'randomiseTestForest': inside a
+-- 'DoNotRandomiseExecutionOrder' scope it leaves the whole subtree as-is at
+-- every depth, and the caller only applies it when the suite's execution-order
+-- randomisation is enabled.
+--
+-- Only sibling order changes.  Wrapper nodes keep wrapping their own children,
+-- so shared setup and teardown still run once per group and are never split.
+-- The sort is stable, so equal-cost siblings keep their source order.
+--
+-- 'TestId's are assigned with the same scheme as 'flattenTestForestWith', purely
+-- to look costs up; nothing downstream reads the ids of the reordered forest.
+-- When this runs on a forest that 'filterTestForestByTrie' has thinned, the
+-- per-description sibling index of same-named siblings can shift relative to the
+-- baseline map's keys.  That degrades ordering quality for same-named siblings
+-- only, never which tests run.
+reorderTestForestByTiming :: Map TestId Word -> TestForest '[] () -> TestForest '[] ()
+reorderTestForestByTiming costs = snd . goForest []
+  where
+    -- Reorder the sub-forest and report the minimum leaf cost it contains
+    -- ('maxBound' when it contains no leaf, so leafless subtrees sort last).
+    goForest ::
+      [(Text, Word)] ->
+      SpecDefForest outers inner () ->
+      (Word, SpecDefForest outers inner ())
+    goForest path sub =
+      let keyed =
+            reverse $
+              snd $
+                foldl
+                  ( \(seen, acc) tree ->
+                      let (mkey, seen') = nextKey seen tree
+                       in (seen', goTree path mkey tree : acc)
+                  )
+                  (Map.empty, [])
+                  sub
+       in ( if null keyed then maxBound else minimum (map fst keyed),
+            map snd (sortOn fst keyed)
+          )
+
+    goTree ::
+      [(Text, Word)] ->
+      Maybe (Text, Word) ->
+      SpecDefTree outers inner () ->
+      (Word, SpecDefTree outers inner ())
+    goTree path mkey tree = case tree of
+      DefSpecifyNode name td e -> case mkey of
+        Nothing -> (maxBound, tree)
+        Just key ->
+          let tid = TestId (NE.fromList (reverse (key : path)))
+           in (Map.findWithDefault 0 tid costs, DefSpecifyNode name td e)
+      DefPendingNode _ _ -> (maxBound, tree)
+      DefDescribeNode name sub -> case mkey of
+        Nothing -> (maxBound, tree)
+        Just key ->
+          let (cost, sub') = goForest (key : path) sub
+           in (cost, DefDescribeNode name sub')
+      DefSetupNode func sub -> wrap (DefSetupNode func) path sub
+      DefBeforeAllNode func sub -> wrap (DefBeforeAllNode func) path sub
+      DefBeforeAllWithNode func sub -> wrap (DefBeforeAllWithNode func) path sub
+      DefWrapNode func sub -> wrap (DefWrapNode func) path sub
+      DefAroundAllNode func sub -> wrap (DefAroundAllNode func) path sub
+      DefAroundAllWithNode func sub -> wrap (DefAroundAllWithNode func) path sub
+      DefAfterAllNode func sub -> wrap (DefAfterAllNode func) path sub
+      DefParallelismNode p sub -> wrap (DefParallelismNode p) path sub
+      DefTimeoutNode f sub -> wrap (DefTimeoutNode f) path sub
+      DefRetriesNode f sub -> wrap (DefRetriesNode f) path sub
+      DefFlakinessNode fm sub -> wrap (DefFlakinessNode fm) path sub
+      DefExpectationNode em sub -> wrap (DefExpectationNode em) path sub
+      DefRandomisationNode eor sub -> case eor of
+        RandomiseExecutionOrder -> wrap (DefRandomisationNode eor) path sub
+        -- [tag:ReorderRandomiseBoundary] Mirror 'randomiseTestForest': inside a
+        -- 'DoNotRandomiseExecutionOrder' scope, leave the whole subtree as-is at
+        -- every depth.  Still compute its cost (order-invariant) to position the
+        -- node among its own siblings; discard the reordered structure.
+        DoNotRandomiseExecutionOrder ->
+          let (cost, _) = goForest path sub
+           in (cost, DefRandomisationNode eor sub)
+
+    -- Reorder a wrapper's children and keep the wrapper wrapping them.  The
+    -- wrapper contributes no path step (matching 'flattenTestForestWith'), so
+    -- its children stay keyed under the same @path@.
+    wrap ::
+      (SpecDefForest a b () -> SpecDefTree outers inner ()) ->
+      [(Text, Word)] ->
+      SpecDefForest a b () ->
+      (Word, SpecDefTree outers inner ())
+    wrap con path sub =
+      let (cost, sub') = goForest path sub
+       in (cost, con sub')
+
+    -- [ref:ReorderIdScheme] Assign the per-description sibling index exactly as
+    -- 'flattenTestForestWith' does, so cost lookups hit the baseline map.
+    nextKey :: Map Text Word -> SpecDefTree outers inner () -> (Maybe (Text, Word), Map Text Word)
+    nextKey seen tree = case descriptionOf tree of
+      Nothing -> (Nothing, seen)
+      Just t ->
+        let idx = Map.findWithDefault 0 t seen
+         in (Just (t, idx), Map.insert t (idx + 1) seen)
+
+    descriptionOf :: SpecDefTree outers inner () -> Maybe Text
+    descriptionOf = \case
+      DefSpecifyNode t _ _ -> Just t
+      DefPendingNode t _ -> Just t
+      DefDescribeNode t _ -> Just t
+      _ -> Nothing
+
+-- | Decide the execution order for a mutation child's (already filtered)
+-- forest.  Reorder cheapest-first with 'reorderTestForestByTiming' only when
+-- the suite has execution-order randomisation enabled (so this stays a drop-in
+-- alternative to that randomisation) and a baseline is available; otherwise
+-- leave the forest untouched.
+--
+-- Kept pure and separate from the child's IO so the gate is testable: the
+-- child reads the baseline and looks up 'settingRandomiseExecutionOrder', then
+-- hands both here.
+reorderForMutationChild :: Bool -> Maybe (Map TestId Word) -> TestForest '[] () -> TestForest '[] ()
+reorderForMutationChild randomiseEnabled mCosts forest =
+  case (randomiseEnabled, mCosts) of
+    (True, Just costs) -> reorderTestForestByTiming costs forest
+    _ -> forest

--- a/sydtest/src/Test/Syd/MutationMode/Single.hs
+++ b/sydtest/src/Test/Syd/MutationMode/Single.hs
@@ -18,8 +18,9 @@ import Test.Syd.Mutation.AugmentedManifest
     lookupAugmentedMutationRecord,
     readAugmentedManifestFile,
   )
-import Test.Syd.Mutation.Forest (filterTestForestByTrie, testIdTrieFromList)
+import Test.Syd.Mutation.Forest (filterTestForestByTrie, reorderForMutationChild, testIdTrieFromList)
 import Test.Syd.Mutation.Runtime (parseMutationId, setActiveMutation)
+import Test.Syd.Mutation.TestBaselineMap (TestBaselineMap (..), readTestBaselineMapDirIfExists)
 import Test.Syd.Mutation.TestId (TestId)
 import Test.Syd.OptParse
 import Test.Syd.Output (printOutputSpecForest)
@@ -55,8 +56,21 @@ runSingleMutationMode settings mutChild spec = do
       forest = case coveringTests of
         [] -> specForest
         ts -> filterTestForestByTrie (testIdTrieFromList ts) specForest
+  -- Order the covering tests cheapest-first so the fail-fast run reaches a
+  -- killing test sooner.  This is a drop-in alternative to execution-order
+  -- randomisation, so 'reorderForMutationChild' only reorders when the suite
+  -- has randomisation enabled; if the author fixed the order
+  -- (--no-randomise-execution-order), the forest is left as-is.  'execTestDefM'
+  -- above already ran the (seeded) shuffle that keeps ids in sync with the
+  -- coverage phase, which is why the reorder happens after filtering.
+  mBaseline <- readTestBaselineMapDirIfExists (mutationChildAugmentedManifestDir mutChild)
+  let orderedForest =
+        reorderForMutationChild
+          (settingRandomiseExecutionOrder settings)
+          (fmap (\(TestBaselineMap costs) -> costs) mBaseline)
+          forest
   setActiveMutation (Just mid)
-  timedResult <- runSpecForestSynchronously (settings {settingThreads = Synchronous, settingFailFast = True}) forest
+  timedResult <- runSpecForestSynchronously (settings {settingThreads = Synchronous, settingFailFast = True}) orderedForest
   setActiveMutation Nothing
   printOutputSpecForest settings timedResult
   if shouldExitFail settings (timedValue timedResult)

--- a/sydtest/src/Test/Syd/SpecDef.hs
+++ b/sydtest/src/Test/Syd/SpecDef.hs
@@ -281,6 +281,7 @@ randomiseTestForest = goForest
       DefRandomisationNode eor sdf ->
         DefRandomisationNode eor <$> case eor of
           RandomiseExecutionOrder -> goForest sdf
+          -- [ref:ReorderRandomiseBoundary]
           DoNotRandomiseExecutionOrder -> pure sdf
 
 markSpecForestAsPending :: Maybe Text -> SpecDefForest outers inner result -> SpecDefForest outers inner result

--- a/sydtest/sydtest.cabal
+++ b/sydtest/sydtest.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest
-version:        0.27.1.0
+version:        0.27.2.0
 synopsis:       A modern testing framework for Haskell with good defaults and advanced testing features.
 description:    A modern testing framework for Haskell with good defaults and advanced testing features. Sydtest aims to make the common easy and the hard possible. See https://github.com/NorfairKing/sydtest#readme for more information.
 category:       Testing


### PR DESCRIPTION
## What

When a mutation child runs the tests that cover a mutation, it runs them synchronously under fail-fast, so the first covering test that fails kills the mutant. This orders those covering tests **cheapest-first**, using the per-test baseline timing the coverage phase already measures (and, until now, discarded into a single timeout). Reaching a killing test sooner cuts the mutation phase's wall-clock, since killed mutants are the overwhelming majority of a run.

The idea: to minimise expected time to the first success among independent trials with cost `c_i` and (unknown, assumed uniform) kill-probability, order by ascending `c_i`. Shortest-first.

## How

- **`reorderTestForestByTiming`** (`sydtest/.../Mutation/Forest.hs`): a pure, tree-aware, stable reorder. It sorts siblings by ascending baseline (missing = first) and orders each subtree by the minimum cost of any leaf it contains, so a shared-setup group reorders as a unit and setup is never split. It mirrors `randomiseTestForest`: inside a `DoNotRandomiseExecutionOrder` scope it leaves the subtree untouched at every depth. So it is a drop-in alternative to execution-order randomisation, legal under exactly the same conditions.
- **Baselines persisted**: the coverage phase now writes the merged per-test timings as `baseline.json` next to `manifest-augmented.json`; the `run` and `diff` paths union them into the augmented dir the children read.
- **The child** (`MutationMode/Single.hs`) reads that baseline and reorders the filtered forest **after filtering** (so the coverage-order `TestId`s the filter needs are untouched). The gate is a pure, unit-tested helper `reorderForMutationChild` that only reorders when `settingRandomiseExecutionOrder` is on and a baseline is present (if the author fixed the order with `--no-randomise-execution-order`, we respect it).

Only sibling order changes, so verdicts are unaffected: the filter still decides which tests run.

## Results

Full mutation check run on two real projects, without vs with this commit, on the same machine. Fair mutation-phase-only comparison: instrumented suites + coverage warmed untimed (they are cachix-cached in real CI), so only the mutation phase is timed. **Verdicts identical in both** (same killed/survived/uncovered, every per-library score line matches).

| project | covering-test times (min / p90 / max) | without | with | speedup |
|---|---|---|---|---|
| nix-ci | 0.2ms / — / 0.7s | 1814s | 1704s | ~6% |
| really-safe-money | 0ms / 47ms / 35.8s | 530s | 405s | ~24% |

The win scales with the covering tests' time spread: cheapest-first pays off when a mutant's covering set mixes cheap tests with an expensive outlier (killing on a cheap test first avoids ever running the slow one). Projects with a heavy-tailed test-time distribution benefit most.

Caveat: n=1 per project, so treat the exact percentages as indicative (the 24% is well above scheduling noise; the 6% is closer to it). The ceiling is set by kill density and per-mutant process overhead, neither of which this change touches.

## Testing

- New pure unit tests in `sydtest-mutation` (`ReorderSpec`) covering ascending order, stable ties + missing-as-first, that a `Sequential` (parallelism) subtree is reordered but a `DoNotRandomiseExecutionOrder` one is not (incl. no descent into a nested randomise block), that a `beforeAll_` group reorders as a unit without splitting setup, that the test-id set is unchanged, and the gate (reorders when on + baseline; leaves the forest untouched when randomisation is off or no baseline). Confirmed non-vacuous by breaking the sort / the gate and watching them fail.
- `nix flake check` passes.
- End-to-end verdict-unchanged confirmed by the two mutation runs above (identical killed/survived/uncovered tallies).
- `CHANGELOG.md` entry added under `sydtest`.
</content>
