### PR TITLE
Let a scenario carry whether it is a file or a directory

### DIFF
--- a/sydtest-test/default.nix
+++ b/sydtest-test/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation, async, base, bytestring, containers
-, fast-myers-diff, filepath, lib, mtl, opt-env-conf-test, path
-, path-io, QuickCheck, random, safe-coloured-text, stm, sydtest
+, fast-myers-diff, lib, mtl, opt-env-conf-test, path, path-io
+, QuickCheck, random, safe-coloured-text, stm, sydtest
 , sydtest-discover, sydtest-mutation-runtime, text, time, vector
 }:
 mkDerivation {
@@ -9,7 +9,7 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [ base ];
   testHaskellDepends = [
-    async base bytestring containers fast-myers-diff filepath mtl
+    async base bytestring containers fast-myers-diff mtl
     opt-env-conf-test path path-io QuickCheck random safe-coloured-text
     stm sydtest sydtest-mutation-runtime text time vector
   ];

--- a/sydtest-test/package.yaml
+++ b/sydtest-test/package.yaml
@@ -30,7 +30,6 @@ tests:
     - bytestring
     - containers
     - fast-myers-diff
-    - filepath
     - mtl
     - opt-env-conf-test
     - path

--- a/sydtest-test/sydtest-test.cabal
+++ b/sydtest-test/sydtest-test.cabal
@@ -132,7 +132,6 @@ test-suite sydtest-test
     , bytestring
     , containers
     , fast-myers-diff
-    , filepath
     , mtl
     , opt-env-conf-test
     , path

--- a/sydtest-test/test/Test/Syd/ScenarioSpec.hs
+++ b/sydtest-test/test/Test/Syd/ScenarioSpec.hs
@@ -4,26 +4,28 @@ module Test.Syd.ScenarioSpec (spec) where
 
 import Path
 import Path.IO
-import qualified System.FilePath as FilePath
 import Test.Syd
 import Test.Syd.OptParse
 
 spec :: Spec
 spec = do
-  scenarioDir "test_resources/even" $ \rf ->
+  let evens = [reldir|test_resources/even|]
+  scenarioDir evens $ \rf ->
     it "contains an even number" $ do
-      s <- readFile rf
+      s <- readFile (fromRelFile (evens </> rf))
       n <- readIO s
       (n :: Int) `shouldSatisfy` even
-  scenarioDirRecur "test_resources/odd" $ \rf ->
+  let odds = [reldir|test_resources/odd|]
+  scenarioDirRecur odds $ \rf ->
     it "contains an odd number" $ do
-      s <- readFile rf
+      s <- readFile (fromRelFile (odds </> rf))
       n <- readIO s
       (n :: Int) `shouldSatisfy` odd
-  scenarioDirOfDirs "test_resources/same" $ \rd ->
+  let sames = [reldir|test_resources/same|]
+  scenarioDirOfDirs sames $ \rd ->
     it "contains two files with the same contents" $ do
-      a <- readFile (rd FilePath.</> "a")
-      b <- readFile (rd FilePath.</> "b")
+      a <- readFile (fromRelFile (sames </> rd </> [relfile|a|]))
+      b <- readFile (fromRelFile (sames </> rd </> [relfile|b|]))
       a `shouldBe` b
 
   describe "scenarioDir" $ do
@@ -31,7 +33,7 @@ spec = do
       withSystemTempDir "sydtest-scenario" $ \tdir -> do
         specForest <-
           execTestDefM defaultSettings $
-            scenarioDir (fromAbsDir tdir) $ \fp ->
+            scenarioDir tdir $ \fp ->
               it "is never defined" $ fp `shouldBe` fp
         resultForest <- runSpecForestSynchronously defaultSettings specForest
         let stats = computeTestSuiteStats defaultSettings (timedValue resultForest)
@@ -42,7 +44,7 @@ spec = do
       withSystemTempDir "sydtest-scenario" $ \tdir -> do
         specForest <-
           execTestDefM defaultSettings $
-            scenarioDir (fromAbsDir (tdir </> [reldir|nonexistent|])) $ \fp ->
+            scenarioDir (tdir </> [reldir|nonexistent|]) $ \fp ->
               it "is never defined" $ fp `shouldBe` fp
         resultForest <- runSpecForestSynchronously defaultSettings specForest
         let stats = computeTestSuiteStats defaultSettings (timedValue resultForest)
@@ -55,7 +57,7 @@ spec = do
         createDir (tdir </> [reldir|subdir|])
         specForest <-
           execTestDefM defaultSettings $
-            scenarioDirRecur (fromAbsDir tdir) $ \fp ->
+            scenarioDirRecur tdir $ \fp ->
               it "is never defined" $ fp `shouldBe` fp
         resultForest <- runSpecForestSynchronously defaultSettings specForest
         let stats = computeTestSuiteStats defaultSettings (timedValue resultForest)
@@ -70,9 +72,9 @@ spec = do
         writeFile (fromAbsFile (tdir </> [relfile|loose-file|])) ""
         specForest <-
           execTestDefM defaultSettings $
-            scenarioDirOfDirs (fromAbsDir tdir) $ \fp ->
-              it "is the scenario directory" $
-                fp `shouldBe` fromAbsDir tdir FilePath.</> "scenario"
+            scenarioDirOfDirs tdir $ \fp ->
+              it "is the scenario directory, relative to the one given" $
+                fp `shouldBe` [reldir|scenario|]
         resultForest <- runSpecForestSynchronously defaultSettings specForest
         let stats = computeTestSuiteStats defaultSettings (timedValue resultForest)
         testSuiteStatSuccesses stats `shouldBe` 1
@@ -83,7 +85,7 @@ spec = do
         writeFile (fromAbsFile (tdir </> [relfile|loose-file|])) ""
         specForest <-
           execTestDefM defaultSettings $
-            scenarioDirOfDirs (fromAbsDir tdir) $ \fp ->
+            scenarioDirOfDirs tdir $ \fp ->
               it "is never defined" $ fp `shouldBe` fp
         resultForest <- runSpecForestSynchronously defaultSettings specForest
         let stats = computeTestSuiteStats defaultSettings (timedValue resultForest)

--- a/sydtest/CHANGELOG.md
+++ b/sydtest/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.30.0.0] - 2026-09-02
+
+### Changed
+
+* `scenarioDir`, `scenarioDirRecur` and `scenarioDirOfDirs` take a `Path b Dir`
+  and hand the callback a `Path Rel File` or a `Path Rel Dir`, where they took
+  and gave a `FilePath` before.  A scenario now carries whether it is a file or
+  a directory in its type, which is what a caller had to know and could not be
+  told.
+
+  The scenario is relative to the directory given rather than to the working
+  directory, so it is the name to say the test is about, and joining it to the
+  directory is what reads it.  Neither has to be recovered from the other, which
+  a joined path made a caller wanting the name do by hand.
+
+  Call sites pass `[reldir|test_resources/scenarios|]` where they passed
+  `"test_resources/scenarios"`, and join the scenario to it where they used the
+  path as a `FilePath`.
+
+  Test descriptions are unchanged, so a `--filter` over them still selects the
+  same tests.
+
 ## [0.29.0.0] - 2026-08-19
 
 ### Added

--- a/sydtest/default.nix
+++ b/sydtest/default.nix
@@ -7,7 +7,7 @@
 }:
 mkDerivation {
   pname = "sydtest";
-  version = "0.29.0.0";
+  version = "0.30.0.0";
   src = ./.;
   libraryHaskellDepends = [
     async autodocodec base bytestring containers deepseq dlist

--- a/sydtest/package.yaml
+++ b/sydtest/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest
-version: 0.29.0.0
+version: 0.30.0.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest/src/Test/Syd/Def/Scenario.hs
+++ b/sydtest/src/Test/Syd/Def/Scenario.hs
@@ -19,15 +19,20 @@ import Test.Syd.Expectation
 -- instead, because that usually means the scenario files were omitted by
 -- accident.
 --
+-- The scenario is given relative to the directory, so it is the name to say the
+-- test is about and joining it to the directory is what reads it. Neither has to
+-- be recovered from the other.
+--
 -- Example:
 --
--- >   scenarioDir "test_resources/even" $ \fp ->
+-- >   let dir = [reldir|test_resources/even|]
+-- >   scenarioDir dir $ \rf ->
 -- >     it "contains an even number" $ do
--- >       s <- readFile fp
+-- >       s <- readFile (fromRelFile (dir </> rf))
 -- >       n <- readIO s
 -- >       (n :: Int) `shouldSatisfy` even
-scenarioDir :: FilePath -> (FilePath -> TestDefM outers inner ()) -> TestDefM outers inner ()
-scenarioDir = scenarioDirHelper "files" (fmap (map fromRelFile . snd) . listDirRel)
+scenarioDir :: Path b Dir -> (Path Rel File -> TestDefM outers inner ()) -> TestDefM outers inner ()
+scenarioDir = scenarioDirHelper "files" (fmap snd . listDirRel)
 
 -- | Define a test for each file in the given directory, recursively.
 --
@@ -37,13 +42,14 @@ scenarioDir = scenarioDirHelper "files" (fmap (map fromRelFile . snd) . listDirR
 --
 -- Example:
 --
--- >   scenarioDirRecur "test_resources/odd" $ \fp ->
+-- >   let dir = [reldir|test_resources/odd|]
+-- >   scenarioDirRecur dir $ \rf ->
 -- >     it "contains an odd number" $ do
--- >       s <- readFile fp
+-- >       s <- readFile (fromRelFile (dir </> rf))
 -- >       n <- readIO s
 -- >       (n :: Int) `shouldSatisfy` odd
-scenarioDirRecur :: FilePath -> (FilePath -> TestDefM outers inner ()) -> TestDefM outers inner ()
-scenarioDirRecur = scenarioDirHelper "files" (fmap (map fromRelFile . snd) . listDirRecurRel)
+scenarioDirRecur :: Path b Dir -> (Path Rel File -> TestDefM outers inner ()) -> TestDefM outers inner ()
+scenarioDirRecur = scenarioDirHelper "files" (fmap snd . listDirRecurRel)
 
 -- | Define a test for each subdirectory of the given directory.
 --
@@ -57,32 +63,38 @@ scenarioDirRecur = scenarioDirHelper "files" (fmap (map fromRelFile . snd) . lis
 --
 -- Example:
 --
--- >   scenarioDirOfDirs "test_resources/same" $ \fp ->
+-- >   let dir = [reldir|test_resources/same|]
+-- >   scenarioDirOfDirs dir $ \rd ->
 -- >     it "contains two files with the same contents" $ do
--- >       a <- readFile (fp </> "a")
--- >       b <- readFile (fp </> "b")
+-- >       a <- readFile (fromRelFile (dir </> rd </> [relfile|a|]))
+-- >       b <- readFile (fromRelFile (dir </> rd </> [relfile|b|]))
 -- >       a `shouldBe` b
-scenarioDirOfDirs :: FilePath -> (FilePath -> TestDefM outers inner ()) -> TestDefM outers inner ()
-scenarioDirOfDirs =
-  scenarioDirHelper
-    "directories"
-    (fmap (map (FP.dropTrailingPathSeparator . fromRelDir) . fst) . listDirRel)
+scenarioDirOfDirs :: Path b Dir -> (Path Rel Dir -> TestDefM outers inner ()) -> TestDefM outers inner ()
+scenarioDirOfDirs = scenarioDirHelper "directories" (fmap fst . listDirRel)
 
 scenarioDirHelper ::
   -- | What the lister looks for, for the description of the failing test that
   -- an empty scenario directory produces.
   String ->
   -- | The scenarios, relative to the given directory
-  (Path Abs Dir -> IO [FilePath]) ->
-  FilePath ->
-  (FilePath -> TestDefM outers inner ()) ->
+  (Path Abs Dir -> IO [Path Rel t]) ->
+  Path b Dir ->
+  (Path Rel t -> TestDefM outers inner ()) ->
   TestDefM outers inner ()
-scenarioDirHelper noun lister dp func =
-  describe dp $ do
-    ad <- liftIO $ resolveDir' dp
+scenarioDirHelper noun lister dir func =
+  describe (described dir) $ do
+    ad <- liftIO $ makeAbsolute dir
     ss <- liftIO $ fmap (fromMaybe []) $ forgivingAbsence $ lister ad
     if null ss
       then it (unwords ["has scenario", noun]) $ \_ ->
-        (expectationFailure $ unwords ["No scenario", noun, "found in", dp] :: IO ())
+        (expectationFailure $ unwords ["No scenario", noun, "found in", described dir] :: IO ())
       else forM_ ss $ \s ->
-        describe s $ func (dp FP.</> s)
+        describe (described s) $ func s
+
+-- | A path as a test description.
+--
+-- The separator a directory's rendering ends in comes off, so that a scenario
+-- reads the same whether it is a file or a directory, and so that these
+-- descriptions are the ones they were before the scenarios became typed.
+described :: Path b t -> String
+described = FP.dropTrailingPathSeparator . toFilePath

--- a/sydtest/sydtest.cabal
+++ b/sydtest/sydtest.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest
-version:        0.29.0.0
+version:        0.30.0.0
 synopsis:       A modern testing framework for Haskell with good defaults and advanced testing features.
 description:    A modern testing framework for Haskell with good defaults and advanced testing features. Sydtest aims to make the common easy and the hard possible. See https://github.com/NorfairKing/sydtest#readme for more information.
 category:       Testing


### PR DESCRIPTION
`scenarioDir`, `scenarioDirRecur` and `scenarioDirOfDirs` took a `FilePath` and handed the callback a `FilePath`, so the one thing a caller has to know about a scenario, whether it is a file or a directory, was the one thing the type would not tell them. `scenarioDirOfDirs` handing out a directory and `scenarioDir` handing out a file had the same signature.

They now take a `Path b Dir` and hand over a `Path Rel File` or a `Path Rel Dir`.

## Relative to the directory given

Not to the working directory. The scenario is then the name to say the test is about, and joining it to the directory is what reads it:

```haskell
let dir = [reldir|test_resources/even|]
scenarioDir dir $ \rf ->
  it "contains an even number" $ do
    s <- readFile (fromRelFile (dir </> rf))
    ...
```

Neither has to be recovered from the other. Handing over the joined path instead made a caller who wanted the name split it back apart, which is what the `FilePath` version did.

The directory stays polymorphic in its base, so a scenario over a `withSystemTempDir` still works with the absolute path it hands you, which is what this repository's own `ScenarioSpec` does.

## Breaking

The signatures changed rather than gaining typed siblings, so this is a major bump to 0.30.0.0. Call sites pass `[reldir|test_resources/scenarios|]` where they passed `"test_resources/scenarios"`, and join the scenario to the directory where they used the path as a `FilePath`.

Test descriptions are unchanged, separator and all, so a `--filter` over them still selects the same tests.

## What it bought

`sydtest-test` no longer depends on `filepath`. Joining a scenario directory to a file inside it was the only thing it wanted `System.FilePath` for, and `Path`'s own `</>` does that with the types lined up.

Downstream, NorfairKing/hopinion#13 is what asked for this: `scenarioDir` handing out a `FilePath` forced the type into the signature of everything called from inside one.

## Review loop

```
nix build .#checks.x86_64-linux.release
```
