### PR TITLE
Let ConstEmptyList be skipped by the call its list is an argument of

### DIFF
--- a/nix/mutation.yaml
+++ b/nix/mutation.yaml
@@ -56,3 +56,11 @@ operators:
   ListLit:
     skip-calls-to:
       - report
+  # 'ConstEmptyList' reaches the same lists from the other side, by their type
+  # rather than their syntax, so it takes the same entry. Sharing 'report' with
+  # 'ListLit' above is what leaves Example.ListLitCallsLib with no ANN pragma
+  # at all: both operators are answered by this config, which is the point of
+  # the key, since a list inside an instance method has no binding to annotate.
+  ConstEmptyList:
+    skip-calls-to:
+      - report

--- a/sydtest-mutation-example/src/Example/ListLitCallsLib.hs
+++ b/sydtest-mutation-example/src/Example/ListLitCallsLib.hs
@@ -16,9 +16,8 @@ where
 -- second test of that.
 --
 -- 'ConstEmptyList' would otherwise fire on the argument lists below, which
--- are the same lists this is about; disable that one operator so what is left
--- is only what 'ListLit' does.
-{-# ANN report ("DisableMutation: ConstEmptyList" :: String) #-}
+-- are the same lists this is about. It is answered by the same
+-- @skip-calls-to@ entry, under its own name, so there is no pragma here.
 report :: String -> Int
 report = length
 
@@ -26,13 +25,11 @@ report = length
 -- applications in, since @mconcat@ is the call it is the immediate argument
 -- of, so only matching an enclosing call rather than the immediate one
 -- suppresses it.
-{-# ANN reportPlain ("DisableMutation: ConstEmptyList" :: String) #-}
 reportPlain :: String -> Int
 reportPlain x = report (mconcat ["problem: ", x])
 
 -- | @$@ application: @report $ mconcat [...]@.  GHC expands @$@ into an
 -- @HsApp@ chain whose head is @$@ rather than @report@, so the callee has to
 -- be read through it.
-{-# ANN reportDollar ("DisableMutation: ConstEmptyList" :: String) #-}
 reportDollar :: String -> Int
 reportDollar x = report $ mconcat ["problem: ", x]

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ConstEmptyList.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Operator/ConstEmptyList.hs
@@ -10,14 +10,29 @@ import GHC
 import GHC.Builtin.Types (charTyCon, listTyCon)
 import GHC.Core.Type (tyConAppTyCon_maybe)
 import Test.Syd.Mutation.Plugin.Instrument (InstrM, InstrumentEnv (..), MutationAlt (..), MutationOperator (..), MutationOperatorKind (..), OpAppCtx (..), SrcSpanDelta (..))
-import Test.Syd.Mutation.Plugin.Operator.Util (ConstFnMatch (..), arrowTy, mkConstLambda, prefixFormPreview, unwrapWrap, viewConstFnResult)
-import Test.Syd.Mutation.Plugin.OptParse (OperatorConfig (..), operatorExtraFlag)
+import Test.Syd.Mutation.Plugin.Operator.Util (ConstFnMatch (..), arrowTy, mkConstLambda, nameMatchCandidates, prefixFormPreview, unwrapWrap, viewConstFnResult)
+import Test.Syd.Mutation.Plugin.OptParse (OperatorConfig (..), operatorExtraFlag, operatorExtraStrings)
 
 -- | Replace an expression whose type is @arg1 -> ... -> argN -> [a]@
 -- (with @N >= 0@) with the constant function returning @[]@.
 --
 -- Same shape and rationale as 'ConstNothing'; see that module's haddock.
 -- Complements 'ListLit', which targets the syntactic 'ExplicitList' form.
+--
+-- It complements it in @skip-calls-to@ too, with the same meaning and the same
+-- matching: a list holding the pieces of a message is a list nobody asserts
+-- the elements of, and emptying it is a mutant that can only be killed by
+-- pinning wording. Naming the calls that take a message reaches those lists
+-- wherever they are written, including inside an instance method, which is
+-- where an @ANN@ pragma cannot go.
+--
+-- > operators:
+-- >   ConstEmptyList:
+-- >     skip-calls-to:
+-- >       - fail
+--
+-- 'ListLit' documents why any enclosing call counts rather than only the
+-- immediate one.
 theOperator :: MutationOperator
 theOperator =
   MutationOperator
@@ -39,9 +54,17 @@ action le elTy ConstFnMatch {cfnArgTys, cfnResTy} = do
   appDepth <- asks instrumentEnvAppDepth
   -- This operator interprets its own config entry's extra keys.
   opsConfig <- asks instrumentEnvOperatorsConfig
+  rdrEnv <- asks instrumentEnvRdrEnv
+  enclosing <- asks instrumentEnvEnclosingCalls
   let extra = maybe Map.empty operatorConfigExtra (Map.lookup "ConstEmptyList" opsConfig)
       skipStrings = operatorExtraFlag "skip-strings" extra
       skipLiteralStrings = operatorExtraFlag "skip-literal-strings" extra
+      skipCallsTo = operatorExtraStrings "skip-calls-to" extra
+      skippedByCall =
+        not (null skipCallsTo)
+          && any
+            (\n -> any (`elem` skipCallsTo) (nameMatchCandidates rdrEnv n))
+            enclosing
       arity = length cfnArgTys
       -- 'skip-strings' drops every @[Char]@-typed expression; the narrower
       -- 'skip-literal-strings' drops only syntactic string literals.
@@ -49,7 +72,7 @@ action le elTy ConstFnMatch {cfnArgTys, cfnResTy} = do
         (skipStrings && isCharElemTy elTy)
           || (skipLiteralStrings && isCharElemTy elTy && isStringLiteralExpr le)
   -- See 'ConstNothing' for the dominance rule.
-  if (arity >= 1 && appDepth >= arity) || skippedAsString
+  if (arity >= 1 && appDepth >= arity) || skippedAsString || skippedByCall
     then pure []
     else
       let emptyExpr = noLocA (ExplicitList elTy [])


### PR DESCRIPTION
Follow-up to #138, which gave `ListLit` a `skip-calls-to` key. `ConstEmptyList`
reaches the same lists from the other side — by their type rather than their
syntax — and had no way to be told the same thing.

A list holding the pieces of a message is a list nobody asserts the elements
of, so emptying it yields a mutant that can only be killed by pinning wording.
The key means the same here and matches the same way: any *enclosing* call, not
only the immediate one, because the call such a list is the immediate argument
of is always `mconcat` or `unwords`, never the function that says what the
message is for.

### Why a config key rather than an `ANN` pragma

A message built inside an instance method has no binding to annotate, and
codecs, `PersistField` instances and job handlers are all written that way. In
the repository this came from, 13 of the message sites were inside instance
methods; the alternative was asserting the exact wording in a test, which is
what the key exists to avoid.

### The example is now the test for both

`Example.ListLitCallsLib` carries **no `ANN` pragma at all**. The three it had
were disabling `ConstEmptyList` on the very lists this key is about, and one
shared `skip-calls-to` entry answers both operators. That also makes the module
a check on dead disable targets, since a pragma naming an operator with no
remaining mutant fails the check.

### Asserted

Removing the `ConstEmptyList` entry fails `mutation-sydtest-mutation-example`
with the two `ConstEmptyList` mutants in `reportDollar`
(`ListLitCallsLib.hs:35`); putting it back passes. Both directions were run.
