### PR TITLE
Let a constructor say what a list is for

### DIFF
--- a/nix/mutation.yaml
+++ b/nix/mutation.yaml
@@ -56,6 +56,7 @@ operators:
   ListLit:
     skip-calls-to:
       - report
+      - Codes
   # 'ConstEmptyList' reaches the same lists from the other side, by their type
   # rather than their syntax, so it takes the same entry. Sharing 'report' with
   # 'ListLit' above is what leaves Example.ListLitCallsLib with no ANN pragma
@@ -64,3 +65,4 @@ operators:
   ConstEmptyList:
     skip-calls-to:
       - report
+      - Codes

--- a/sydtest-mutation-example/src/Example/ListLitCallsLib.hs
+++ b/sydtest-mutation-example/src/Example/ListLitCallsLib.hs
@@ -1,5 +1,7 @@
 module Example.ListLitCallsLib
   ( report,
+    Codes (..),
+    reportCodes,
     reportPlain,
     reportDollar,
   )
@@ -33,3 +35,15 @@ reportPlain x = report (mconcat ["problem: ", x])
 -- be read through it.
 reportDollar :: String -> Int
 reportDollar x = report $ mconcat ["problem: ", x]
+
+-- | What 'reportCodes' answers with, so that there is a constructor to name.
+newtype Codes = Codes [Int]
+
+-- | A constructor application says what a list is for exactly as a function
+-- call does, so 'Codes' is listed under both operators' @skip-calls-to@ in the
+-- plugin config and the list literal here yields no mutation.
+--
+-- A constructor of this module's own rather than one of 'Either''s, so that
+-- what is skipped is one named constructor and not every 'Left' in the suite.
+reportCodes :: Int -> Codes
+reportCodes x = Codes (mconcat [[x], [x]])

--- a/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Instrument.hs
+++ b/sydtest-mutation-plugin/src/Test/Syd/Mutation/Plugin/Instrument.hs
@@ -46,6 +46,7 @@ import qualified Data.Text.Encoding as TE
 -- 'GHC.Runtime.Eval', which clashes with the 'GHC.Core.Type.typeKind' used below.
 import GHC hiding (typeKind)
 import GHC.Builtin.Types (charTy, manyDataConTy, mkListTy)
+import GHC.Core.ConLike (conLikeName)
 import GHC.Core.Predicate (isEvVar)
 import GHC.Core.TyCo.Rep (Scaled (..))
 import GHC.Core.Type (isLiftedTypeKind, typeKind)
@@ -1078,7 +1079,7 @@ origBindStmtBinders = \case
 applicationCallee :: LHsExpr GhcTc -> Maybe Name
 applicationCallee fnSide =
   let (hd, args) = collectApp fnSide
-   in case headFunctionName hd of
+   in case calleeName hd of
         Just n
           | getOccString n == "$",
             (leftArg : _) <- args ->
@@ -1087,7 +1088,32 @@ applicationCallee fnSide =
 
 -- | The name at the head of an application, whatever it is applied to.
 headOf :: LHsExpr GhcTc -> Maybe Name
-headOf = headFunctionName . fst . collectApp
+headOf = calleeName . fst . collectApp
+
+-- | The name at the head of an application, for the purpose of saying which
+-- call an expression is inside.
+--
+-- A data constructor counts. @Left (mconcat [..])@ is an application whose
+-- head says what the list is for exactly as @fail (mconcat [..])@ does, and a
+-- codec or a column rejecting what it was handed says so by returning a
+-- @Left@. Read here rather than in 'headFunctionName', which several operators
+-- use to decide what is an elidable or swappable /call/: a constructor is not
+-- one of those, and teaching that function about constructors would change
+-- which mutants they produce.
+calleeName :: LHsExpr GhcTc -> Maybe Name
+calleeName le = case headFunctionName le of
+  Just n -> Just n
+  Nothing -> constructorName le
+
+-- | The 'Name' of a data constructor at its post-typechecking 'ConLikeTc'
+-- node, which is what GHC rewrites a constructor's 'HsVar' into.
+constructorName :: LHsExpr GhcTc -> Maybe Name
+constructorName le = case unLoc le of
+  XExpr (ConLikeTc con _ _) -> Just (conLikeName con)
+  XExpr (WrapExpr (HsWrap _ e)) -> constructorName (noLocA e)
+  HsAppType _ f _ -> constructorName f
+  HsPar _ e -> constructorName e
+  _ -> Nothing
 
 -- | Whether this operator is @$@, which stands for application rather than
 -- being a call of its own.


### PR DESCRIPTION
Third in the line of #138 and #139. `skip-calls-to` reads the call an
expression is inside, and a data constructor was not one of them.

A codec or a database column rejecting what it was handed says so by returning
`Left` of a message assembled from pieces. The constructor is exactly the call
that says what that list is for — the same role `fail` or `error` plays one
application further out — so it should be nameable.

### Why not in `headFunctionName`

Several operators use `headFunctionName` to decide what is an elidable or a
swappable *call*, and a constructor is neither. Teaching it about constructors
would change which mutants those produce, which is not the intent. The new
`calleeName` is used only where enclosing calls are recorded, and falls back to
the constructor's name at the `ConLikeTc` node GHC rewrites a constructor's
`HsVar` into — the same node `BoolLit`, `ConstBool`, `MaybeOp` and
`ConstConstructor` already read.

### What it is worth

Without it, a message built inside an instance method can only be answered by
asserting its wording in a test, since there is no binding for an `ANN` pragma
to name. In the repository this came from that was eight messages, and the
workaround cost eight extracted functions, eight pragmas and seven `ElideCall`
entries. One `Left` entry replaces all of it.

### Asserted

`Example.ListLitCallsLib.reportEither` is the case. Removing the `Left` entry
fails `mutation-sydtest-mutation-example` with the `ListLit` and
`ConstEmptyList` mutants on its message list; putting it back passes. Both
directions were run.
