### PR TITLE
Let a failed control name the test that killed it

### DIFF
--- a/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/MutateSpec.hs
+++ b/sydtest-mutation-driver-gen/test/Test/Syd/Mutation/Driver/MutateSpec.hs
@@ -4,18 +4,22 @@
 module Test.Syd.Mutation.Driver.MutateSpec (spec) where
 
 import qualified Control.Exception as Exception
+import Data.List (isInfixOf)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
-import Path (fromAbsFile, parseAbsDir, relfile, (</>))
-import Path.IO (canonicalizePath, getPermissions, setOwnerExecutable, setPermissions, withSystemTempDir)
+import Path (fromAbsFile, fromRelFile, parseAbsDir, relfile, (</>))
+import Path.IO (canonicalizePath, getPermissions, listDirRel, setOwnerExecutable, setPermissions, withSystemTempDir)
 import Test.Syd
 import Test.Syd.Mutation.AugmentedManifest
   ( AugmentedManifest (..),
     AugmentedMutationGroup (..),
     AugmentedMutationRecord (..),
+    ControlFailedMutation (..),
     ControlTally (..),
+    MutationOutcome (..),
     MutationRunReport (..),
     MutationTally (..),
+    mutationGroupReportOutcomes,
     writeAugmentedManifestFile,
   )
 import Test.Syd.Mutation.Driver.Mutate (UnknownCoveringSuite (..), runMutationMode)
@@ -228,3 +232,119 @@ spec = describe "runMutationMode" $ do
         controlTallyPassed (mutationRunReportControls report) `shouldBe` 0
         mutationTallyKilled (mutationRunReportMutations report) `shouldBe` 0
         mutationTallySurvived (mutationRunReportMutations report) `shouldBe` 0
+
+  it "keeps the output of the run that killed a control" $
+    -- A control is a no-op, so a kill means the suite is unsound.  The
+    -- child's output is the only place the test that killed it is named,
+    -- and without it the flaky test behind a control failure cannot be
+    -- found from the report at all.
+    withSystemTempDir "mutate-control-manifest" $ \manifestDir ->
+      withSystemTempDir "mutate-control-out" $ \outDir -> do
+        let exeFile = manifestDir </> [relfile|suite-exe|]
+        writeFile
+          (fromAbsFile exeFile)
+          (unlines ["#!/bin/sh", "echo 'FAIL the flaky one'", "exit 1"])
+        perms <- getPermissions exeFile
+        setPermissions exeFile (setOwnerExecutable True perms)
+        let record =
+              AugmentedMutationRecord
+                { augmentedMutationRecordId = MutationId ["M", "Control", "1", "1", "2"],
+                  augmentedMutationRecordOperator = controlOperatorName,
+                  augmentedMutationRecordOriginal = "no-op",
+                  augmentedMutationRecordReplacement = "no-op",
+                  augmentedMutationRecordModule = "M",
+                  augmentedMutationRecordLine = 1,
+                  augmentedMutationRecordEndLine = 1,
+                  augmentedMutationRecordColStart = 1,
+                  augmentedMutationRecordColEnd = 2,
+                  augmentedMutationRecordSourceFile = Nothing,
+                  augmentedMutationRecordSourceLines = [],
+                  augmentedMutationRecordMutatedLines = [],
+                  augmentedMutationRecordContextBefore = [],
+                  augmentedMutationRecordContextAfter = [],
+                  augmentedMutationRecordCoveringTests =
+                    Map.singleton "suite" [TestId (("t", 0) :| [])],
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
+                }
+        writeAugmentedManifestFile
+          manifestDir
+          (AugmentedManifest [AugmentedMutationGroup [record]])
+        report <-
+          runMutationMode
+            False
+            False
+            manifestDir
+            outDir
+            Nothing
+            Nothing
+            ( Map.singleton
+                "suite"
+                SuiteConfig
+                  { suiteConfigExe = exeFile,
+                    suiteConfigResourceDir = Nothing
+                  }
+            )
+        let outcomes = concatMap mutationGroupReportOutcomes (mutationRunReportGroups report)
+        case [cf | OutcomeControlFailed cf <- outcomes] of
+          [cf] -> case controlFailedMutationLogFile cf of
+            Nothing -> expectationFailure "the killed control kept no log to name its test"
+            Just relFile -> do
+              contents <- readFile (fromAbsFile (outDir </> relFile))
+              contents `shouldContain` "FAIL the flaky one"
+          other -> expectationFailure ("expected exactly one control failure, got " ++ show (length other))
+
+  it "keeps no output for an ordinary killed mutation" $
+    -- The overwhelming majority of a healthy run is kills, and their output
+    -- says nothing, so keeping it would be a log per mutation.
+    withSystemTempDir "mutate-killed-manifest" $ \manifestDir ->
+      withSystemTempDir "mutate-killed-out" $ \outDir -> do
+        let exeFile = manifestDir </> [relfile|suite-exe|]
+        writeFile
+          (fromAbsFile exeFile)
+          (unlines ["#!/bin/sh", "echo 'killed it'", "exit 1"])
+        perms <- getPermissions exeFile
+        setPermissions exeFile (setOwnerExecutable True perms)
+        let record =
+              AugmentedMutationRecord
+                { augmentedMutationRecordId = MutationId ["M", "Op", "1", "1", "2"],
+                  augmentedMutationRecordOperator = "Op",
+                  augmentedMutationRecordOriginal = "+",
+                  augmentedMutationRecordReplacement = "-",
+                  augmentedMutationRecordModule = "M",
+                  augmentedMutationRecordLine = 1,
+                  augmentedMutationRecordEndLine = 1,
+                  augmentedMutationRecordColStart = 1,
+                  augmentedMutationRecordColEnd = 2,
+                  augmentedMutationRecordSourceFile = Nothing,
+                  augmentedMutationRecordSourceLines = [],
+                  augmentedMutationRecordMutatedLines = [],
+                  augmentedMutationRecordContextBefore = [],
+                  augmentedMutationRecordContextAfter = [],
+                  augmentedMutationRecordCoveringTests =
+                    Map.singleton "suite" [TestId (("t", 0) :| [])],
+                  augmentedMutationRecordTimeoutMicros = 30000000,
+                  augmentedMutationRecordBinding = Nothing,
+                  augmentedMutationRecordMitigation = Nothing
+                }
+        writeAugmentedManifestFile
+          manifestDir
+          (AugmentedManifest [AugmentedMutationGroup [record]])
+        _ <-
+          runMutationMode
+            False
+            False
+            manifestDir
+            outDir
+            Nothing
+            Nothing
+            ( Map.singleton
+                "suite"
+                SuiteConfig
+                  { suiteConfigExe = exeFile,
+                    suiteConfigResourceDir = Nothing
+                  }
+            )
+        logs <- listDirRel outDir
+        filter (isInfixOf "control-failure-" . fromRelFile) (snd logs) `shouldBe` []

--- a/sydtest-mutation-driver/CHANGELOG.md
+++ b/sydtest-mutation-driver/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.0.0] - 2026-09-11
+
+### Fixed
+
+* The output of the run that killed a control is kept, so the flaky test behind
+  a control failure can be found.
+
+
+
 ## [0.1.0.0] - 2026-07-16
 
 * First released version.

--- a/sydtest-mutation-driver/default.nix
+++ b/sydtest-mutation-driver/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "sydtest-mutation-driver";
-  version = "0.1.0.0";
+  version = "0.2.0.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/sydtest-mutation-driver/package.yaml
+++ b/sydtest-mutation-driver/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest-mutation-driver
-version: 0.1.0.0
+version: 0.2.0.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/Mutate.hs
+++ b/sydtest-mutation-driver/src/Test/Syd/Mutation/Driver/Mutate.hs
@@ -281,15 +281,16 @@ runMutationMode failFast debug augDir outDir childMemLimit mutationJobs suiteCon
             -- timeout is the control failing (the suite is unsound).
             pure $
               if isControlOperator (augmentedMutationRecordOperator record)
-                then asControlResult (classifyOutcomes record outcomes)
+                then asControlResult outcomes (classifyOutcomes record outcomes)
                 else classifyOutcomes record outcomes
 
     -- Map a control mutation's raw classification onto the control-specific
     -- results.  An uncovered control never reaches here (it short-circuits
     -- above), and 'classifyOutcomes' only ever yields killed/timed-out/survived.
-    asControlResult = \case
+    asControlResult outcomes = \case
       MutationSurvived sm -> MutationControlPassed (survivedMutationRecord sm)
-      MutationKilled record -> MutationControlFailed (ControlFailedMutation record Nothing)
+      MutationKilled record ->
+        MutationControlFailed (ControlFailedMutation record (killingSuiteLog outcomes))
       MutationTimedOut tm ->
         MutationControlFailed
           (ControlFailedMutation (timedOutMutationRecord tm) (timedOutMutationLogFile tm))
@@ -317,9 +318,15 @@ runMutationMode failFast debug augDir outDir childMemLimit mutationJobs suiteCon
                     listToMaybe [rf | SuiteSurvived (Just rf) <- NE.toList outcomes]
                 }
       where
-        isKilled SuiteKilled = True
+        isKilled (SuiteKilled _) = True
         isKilled _ = False
         mTimedOut = listToMaybe [(micros, mLog) | SuiteTimedOut micros mLog <- NE.toList outcomes]
+
+    -- \| The log of the first suite that killed the mutation, when one was
+    -- kept.  Only a control's kill keeps one (see 'runOneSuite'), which is
+    -- also the only caller.
+    killingSuiteLog outcomes =
+      listToMaybe [rf | SuiteKilled (Just rf) <- NE.toList outcomes]
 
     runOneSuite record mid suiteName = do
       (exe, mResourceDir) <- case Map.lookup suiteName suiteConfigs of
@@ -386,7 +393,17 @@ runMutationMode failFast debug augDir outDir childMemLimit mutationJobs suiteCon
               mRelFile <- copyChildLog "timeout-" mid suiteName logPath
               pure (SuiteTimedOut elapsedMicros mRelFile)
             Right ec -> case ec of
-              ExitFailure _ -> pure SuiteKilled
+              ExitFailure _ -> do
+                -- A kill is the expected outcome and its output says nothing,
+                -- except for a control: a no-op cannot legitimately be killed,
+                -- so the child's output is the only place that names the test
+                -- which killed it, and without it the flaky test behind a
+                -- control failure cannot be found.
+                mRelFile <-
+                  if isControlOperator (augmentedMutationRecordOperator record)
+                    then copyChildLog "control-failure-" mid suiteName logPath
+                    else pure Nothing
+                pure (SuiteKilled mRelFile)
               ExitSuccess -> do
                 mRelFile <- copyChildLog "survivor-" mid suiteName logPath
                 pure (SuiteSurvived mRelFile)

--- a/sydtest-mutation-driver/sydtest-mutation-driver.cabal
+++ b/sydtest-mutation-driver/sydtest-mutation-driver.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest-mutation-driver
-version:        0.1.0.0
+version:        0.2.0.0
 synopsis:       Out-of-process mutation testing driver for sydtest.
 description:    Standalone driver executable that orchestrates the coverage and mutation phases of sydtest's mutation testing infrastructure. Spawns instrumented sydtest test suite executables as children.
 category:       Testing

--- a/sydtest-test/test/Test/Syd/ClassifySyncExceptionAsKilledSpec.hs
+++ b/sydtest-test/test/Test/Syd/ClassifySyncExceptionAsKilledSpec.hs
@@ -28,8 +28,8 @@ import Test.Syd.MutationMode (SuiteOutcome (..), classifySyncExceptionAsKilled)
 spec :: Spec
 spec = describe "classifySyncExceptionAsKilled (bug #2)" $ do
   it "passes through SuiteKilled unchanged" $ do
-    outcome <- classifySyncExceptionAsKilled (pure SuiteKilled)
-    outcome `shouldBe` SuiteKilled
+    outcome <- classifySyncExceptionAsKilled (pure (SuiteKilled Nothing))
+    outcome `shouldBe` SuiteKilled Nothing
 
   it "passes through SuiteSurvived unchanged" $ do
     outcome <- classifySyncExceptionAsKilled (pure (SuiteSurvived Nothing))
@@ -41,15 +41,15 @@ spec = describe "classifySyncExceptionAsKilled (bug #2)" $ do
 
   it "treats BlockedIndefinitelyOnMVar (the <<loop>> case) as SuiteKilled" $ do
     outcome <- classifySyncExceptionAsKilled (throwIO BlockedIndefinitelyOnMVar)
-    outcome `shouldBe` SuiteKilled
+    outcome `shouldBe` SuiteKilled Nothing
 
   it "treats ErrorCall as SuiteKilled" $ do
     outcome <- classifySyncExceptionAsKilled (throwIO (ErrorCall "boom"))
-    outcome `shouldBe` SuiteKilled
+    outcome `shouldBe` SuiteKilled Nothing
 
   it "treats ArithException as SuiteKilled" $ do
     outcome <- classifySyncExceptionAsKilled (throwIO DivideByZero)
-    outcome `shouldBe` SuiteKilled
+    outcome `shouldBe` SuiteKilled Nothing
 
   it "re-throws SomeAsyncException (so Ctrl-C still cancels the runner)" $ do
     -- 'UserInterrupt' is an 'AsyncException', which is a child of
@@ -60,7 +60,7 @@ spec = describe "classifySyncExceptionAsKilled (bug #2)" $ do
         classifySyncExceptionAsKilled $ do
           tid <- myThreadId
           throwTo tid UserInterrupt
-          pure SuiteKilled
+          pure (SuiteKilled Nothing)
     case result :: Either SomeException SuiteOutcome of
       Right _ -> expectationFailure "expected the async exception to be re-thrown"
       Left _ -> pure ()

--- a/sydtest/CHANGELOG.md
+++ b/sydtest/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.31.0.0] - 2026-09-11
+
+### Changed
+
+* `SuiteOutcome`'s `SuiteKilled` carries the killed child's log file.
+
+### Fixed
+
+* A failed control names the output of the run that killed it.
+
+
 ## [0.30.0.0] - 2026-09-02
 
 ### Changed

--- a/sydtest/default.nix
+++ b/sydtest/default.nix
@@ -7,7 +7,7 @@
 }:
 mkDerivation {
   pname = "sydtest";
-  version = "0.30.0.0";
+  version = "0.31.0.0";
   src = ./.;
   libraryHaskellDepends = [
     async autodocodec base bytestring containers deepseq dlist

--- a/sydtest/package.yaml
+++ b/sydtest/package.yaml
@@ -1,5 +1,5 @@
 name: sydtest
-version: 0.30.0.0
+version: 0.31.0.0
 github: "NorfairKing/sydtest"
 license: OtherLicense
 license-file: LICENSE.md

--- a/sydtest/src/Test/Syd/MutationMode/Common.hs
+++ b/sydtest/src/Test/Syd/MutationMode/Common.hs
@@ -114,8 +114,12 @@ data MutationResult
 
 -- | Per-suite outcome of running a single mutation child.
 data SuiteOutcome
-  = -- | Child exited non-zero — mutation killed by this suite.
-    SuiteKilled
+  = -- | Child exited non-zero — mutation killed by this suite.  The optional
+    -- log path points at the captured stdout\/stderr, which is kept only when
+    -- the kill is itself the finding: a killed control.  Keeping it for every
+    -- kill would mean a log per mutation in the manifest, which is the bulk of
+    -- a run and says nothing a passing suite does not.
+    SuiteKilled (Maybe (Path Rel File))
   | -- | Child exited zero — mutation survived in this suite. The optional
     -- log path points at the captured stdout/stderr (when a report dir is
     -- configured).
@@ -140,7 +144,7 @@ classifySyncExceptionAsKilled action =
   Exception.handle
     ( \(e :: Exception.SomeException) -> case Exception.fromException e of
         Just (_ :: Exception.SomeAsyncException) -> Exception.throwIO e
-        Nothing -> pure SuiteKilled
+        Nothing -> pure (SuiteKilled Nothing)
     )
     action
 
@@ -386,7 +390,14 @@ renderMutationRunReport MutationRunReport {..} =
     renderControlFailed cf =
       let rec = controlFailedMutationRecord cf
           mid = augmentedMutationRecordId rec
-       in [] : formatMutationLog mid rec
+          -- The output of the run that killed it is the only place the
+          -- offending test is named, so say where it is rather than leaving
+          -- the reader to know the naming convention.
+          logLines = case controlFailedMutationLogFile cf of
+            Nothing -> []
+            Just relFile ->
+              [[chunk "  Output of the run that killed it: ", fore cyan (chunk (T.pack (fromRelFile relFile)))]]
+       in ([] : formatMutationLog mid rec) ++ logLines
     renderSurvivor sm =
       let rec = survivedMutationRecord sm
           mid = augmentedMutationRecordId rec

--- a/sydtest/sydtest.cabal
+++ b/sydtest/sydtest.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           sydtest
-version:        0.30.0.0
+version:        0.31.0.0
 synopsis:       A modern testing framework for Haskell with good defaults and advanced testing features.
 description:    A modern testing framework for Haskell with good defaults and advanced testing features. Sydtest aims to make the common easy and the hard possible. See https://github.com/NorfairKing/sydtest#readme for more information.
 category:       Testing


### PR DESCRIPTION
A failed control now names the output of the run that killed it.

## The problem

A control is a no-op mutation. It cannot legitimately be killed, so a killed
control means the suite is flaky or the harness is buggy — and the run fails
because of it. But the report said only *that* one had failed, never *which
test* killed it:

```
Failed controls (mutation testing may be unsound):
Control at src/NixCI/Leader/Worker/Notify.hs:120:46-55
```

That is the whole report. `report.json` carries only `{failed: 1, passed: 79}`.
Survivors and timeouts each get a log file; a failed control got none.

The cause is one hardcoded `Nothing`. When a child exits non-zero the driver
records a kill and discards its output:

```haskell
ExitFailure _ -> pure SuiteKilled          -- output dropped
ExitSuccess   -> do mRelFile <- copyChildLog "survivor-" …
```

which is right for the ~1000 ordinary mutations of a healthy run, whose kill is
expected and whose output says nothing. For a control the kill *is* the
finding, so this dropped the evidence at exactly the moment it mattered:

```haskell
MutationKilled record -> MutationControlFailed (ControlFailedMutation record Nothing)
```

## The fix

`SuiteKilled` carries an optional log path, and the driver keeps the log only
when the killed mutation is a control, under a `control-failure-` prefix. So
the report gains one file per control failure, not one per mutation. The
failed-control section then points at it:

```
Control at M.hs:1:1-2 #0
    - no-op
    + no-op
  Output of the run that killed it: control-failure-M-Control-1-1-2-no-op-0-suite.log
```

## How I know it works

Two tests, both end-to-end through `runMutationMode` against a stand-in suite
executable:

* a killed control keeps output that names the test
* an ordinary killed mutation keeps none, so a healthy run does not grow a log
  per mutation

I checked the first one fails without the fix rather than assuming it would:
`the killed control kept no log to name its test`.

## Why now

nix-ci's `mutation-leader-background` failed on exactly this: one control
killed at a time-based wait computation, no way to tell which test did it. I
could not reproduce it (20+ local runs, including 8 concurrent suites, all
clean — it needs the load of a real mutation run), and with no test name there
was nothing to fix but a guess. This turns that into a one-minute diagnosis the
next time it happens.

## Note on versions

`sydtest` goes 0.30 → 0.31 because `SuiteOutcome`'s `SuiteKilled` constructor
gained a field; `sydtest-mutation-driver` goes 0.1 → 0.2.
